### PR TITLE
Hamlib5 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1038,17 +1038,12 @@ find_program (RIGCTLCOM_EXE rigctlcom)
 check_type_size (CACHE_ALL HAMLIB_OLD_CACHING)
 check_symbol_exists (rig_set_cache_timeout_ms "hamlib/rig.h" HAVE_HAMLIB_CACHING)
 
-# Debug
-include (CMakePrintHelpers)
-cmake_print_variables(INCLUDE_DIRECTORIES)
-cmake_print_properties (TARGETS  Hamlib::Hamlib
-                        PROPERTIES LOCATION INTERFACE_INCLUDE_DIRECTORIES)
-# End debug
-set (CMAKE_REQUIRED_INCLUDES "/usr/local/include")
-set (CMAKE_REQUIRED_LIBRARIES hamlib)
-check_include_files ("hamlib/rig.h;hamlib/port.h" HAVE_HAMLIB_PORT_H LANGUAGE CXX)
-check_include_files ("hamlib/rig.h;hamlib/rig_state.h" HAVE_HAMLIB_RIG_STATE_H LANGUAGE CXX)
-cmake_print_variables (HAVE_HAMLIB_PORT_H)
+if (EXISTS ${Hamlib_INCLUDE_DIR}/hamlib/port.h)
+  set (HAVE_HAMLIB_PORT_H 1)
+endif ()
+if (EXISTS ${Hamlib_INCLUDE_DIR}/hamlib/rig_state.h)
+  set (HAVE_HAMLIB_RIG_STATE_H 1)
+endif ()
 
 find_package (Usb REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1038,6 +1038,18 @@ find_program (RIGCTLCOM_EXE rigctlcom)
 check_type_size (CACHE_ALL HAMLIB_OLD_CACHING)
 check_symbol_exists (rig_set_cache_timeout_ms "hamlib/rig.h" HAVE_HAMLIB_CACHING)
 
+# Debug
+include (CMakePrintHelpers)
+cmake_print_variables(INCLUDE_DIRECTORIES)
+cmake_print_properties (TARGETS  Hamlib::Hamlib
+                        PROPERTIES LOCATION INTERFACE_INCLUDE_DIRECTORIES)
+# End debug
+set (CMAKE_REQUIRED_INCLUDES "/usr/local/include")
+set (CMAKE_REQUIRED_LIBRARIES hamlib)
+check_include_files ("hamlib/rig.h;hamlib/port.h" HAVE_HAMLIB_PORT_H LANGUAGE CXX)
+check_include_files ("hamlib/rig.h;hamlib/rig_state.h" HAVE_HAMLIB_RIG_STATE_H LANGUAGE CXX)
+cmake_print_variables (HAVE_HAMLIB_PORT_H)
+
 find_package (Usb REQUIRED)
 
 if (WSJT_FOX_OTP)

--- a/Transceiver/HamlibTransceiver.cpp
+++ b/Transceiver/HamlibTransceiver.cpp
@@ -20,6 +20,21 @@
 #define HAMLIB_CACHE_ALL CACHE_ALL
 #endif
 
+//#if HAVE_HAMLIB_PORT_H
+#include <hamlib/port.h>
+//#endif
+//#if HAVE_HAMLIB_RIG_STATE_H
+#include <hamlib/rig_state.h>
+//#endif
+
+/* Should only be needed to compile with Hamlib < 4.5 */
+#ifndef HAMLIB_STATE
+#  define HAMLIB_STATE(x) (&(x).data().state)
+#endif
+#ifndef HAMLIB_PTTPORT
+#  define HAMLIB_PTTPORT(x) (&(x).data().state.pttport)
+#endif
+
 namespace
 {
   // Unfortunately bandwidth is conflated  with mode, this is probably
@@ -116,13 +131,13 @@ namespace
     hamlib_tx_vfo_fixup (RIG * rig, vfo_t tx_vfo)
       : rig_ {rig}
     {
-      original_vfo_ = rig_->state.tx_vfo;
-      rig_->state.tx_vfo = tx_vfo;
+      original_vfo_ = HAMLIB_STATE(rig_)->tx_vfo;
+      HAMLIB_STATE(rig_)->tx_vfo = tx_vfo;
     }
 
     ~hamlib_tx_vfo_fixup ()
     {
-      rig_->state.tx_vfo = original_vfo_;
+      HAMLIB_STATE(rig_)->tx_vfo = original_vfo_;
     }
 
   private:
@@ -285,6 +300,7 @@ void HamlibTransceiver::impl::error_check (int ret_code, QString const& doing) c
 
 std::tuple<vfo_t, vfo_t> HamlibTransceiver::impl::get_vfos (bool for_split) const
 {
+  struct rig_state *rs = HAMLIB_STATE(rig_.data());
   if (get_vfo_works_ && rig_get_function_ptr (model_, RIG_FUNCTION_GET_VFO))
     {
       vfo_t v;
@@ -300,13 +316,13 @@ std::tuple<vfo_t, vfo_t> HamlibTransceiver::impl::get_vfos (bool for_split) cons
       // support this way around
 
       CAT_TRACE ("rig_set_vfo VFO=A/MAIN");
-      error_check (rig_set_vfo (rig_.data (), rig_->state.vfo_list & RIG_VFO_A ? RIG_VFO_A : RIG_VFO_MAIN), tr ("setting current VFO"));
+      error_check (rig_set_vfo (rig_.data (), rs->vfo_list & RIG_VFO_A ? RIG_VFO_A : RIG_VFO_MAIN), tr ("setting current VFO"));
     }
   // else only toggle available but VFOs should be substitutable 
 
-  auto rx_vfo = rig_->state.vfo_list & RIG_VFO_A ? RIG_VFO_A : RIG_VFO_MAIN;
+  auto rx_vfo = rs->vfo_list & RIG_VFO_A ? RIG_VFO_A : RIG_VFO_MAIN;
   auto tx_vfo = (WSJT_RIG_NONE_CAN_SPLIT || !is_dummy_) && for_split
-    ? (rig_->state.vfo_list & RIG_VFO_B ? RIG_VFO_B : RIG_VFO_SUB)
+    ? (rs->vfo_list & RIG_VFO_B ? RIG_VFO_B : RIG_VFO_SUB)
     : rx_vfo;
   if (reversed_)
     {
@@ -665,7 +681,7 @@ int HamlibTransceiver::do_start ()
       m_->get_vfo_works_ = false;
       // determine if the rig uses single VFO addressing i.e. A/B and
       // no get_vfo function
-      if (m_->rig_->state.vfo_list & RIG_VFO_B)
+      if (HAMLIB_STATE(m_->rig_.data())->vfo_list & RIG_VFO_B)
         {
           m_->one_VFO_ = true;
         }
@@ -706,7 +722,7 @@ int HamlibTransceiver::do_start ()
           else
             {
               CAT_TRACE ("rig_set_vfo to other VFO");
-              rc = rig_set_vfo (m_->rig_.data (), m_->rig_->state.vfo_list & RIG_VFO_B ? RIG_VFO_B : RIG_VFO_SUB);
+              rc = rig_set_vfo (m_->rig_.data (), HAMLIB_STATE(m_->rig_.data())->vfo_list & RIG_VFO_B ? RIG_VFO_B : RIG_VFO_SUB);
               if (-RIG_ENAVAIL == rc || -RIG_ENIMPL == rc)
                 {
                   // if we are talking to netrigctl then toggle VFO op
@@ -749,7 +765,7 @@ int HamlibTransceiver::do_start ()
               else
                 {
                   CAT_TRACE ("rig_set_vfo A/MAIN");
-                  m_->error_check (rig_set_vfo (m_->rig_.data (), m_->rig_->state.vfo_list & RIG_VFO_A ? RIG_VFO_A : RIG_VFO_MAIN), tr ("setting current VFO"));
+                  m_->error_check (rig_set_vfo (m_->rig_.data (), HAMLIB_STATE(m_->rig_.data())->vfo_list & RIG_VFO_A ? RIG_VFO_A : RIG_VFO_MAIN), tr ("setting current VFO"));
                 }
 
               if (f1 != f2 || m != mb || w != wb)	// we must have started with MAIN/A
@@ -908,7 +924,7 @@ void HamlibTransceiver::do_frequency (Frequency f, MODE m, bool no_ignore)
       // for the 1st time as a band change may cause a recalled mode to be
       // set
       vfo_t target_vfo = RIG_VFO_CURR;
-      if (!(m_->rig_->state.vfo_list & RIG_VFO_B))
+      if (!(HAMLIB_STATE(m_->rig_.data())->vfo_list & RIG_VFO_B))
         {
           target_vfo = RIG_VFO_MAIN; // no VFO A/B so force to Rx on MAIN
         }
@@ -1070,7 +1086,7 @@ void HamlibTransceiver::do_mode (MODE mode)
   auto new_mode = m_->map_mode (mode);
 
   vfo_t target_vfo = RIG_VFO_CURR;
-  if (!(m_->rig_->state.vfo_list & RIG_VFO_B))
+  if (!(HAMLIB_STATE(m_->rig_.data())->vfo_list & RIG_VFO_B))
     {
       target_vfo = RIG_VFO_MAIN; // no VFO A/B so force to Rx on MAIN
     }
@@ -1183,8 +1199,8 @@ void HamlibTransceiver::do_poll ()
           // the other one directly because we can't glitch the Rx
           m_->error_check (rig_get_freq (m_->rig_.data ()
                                          , m_->reversed_
-                                         ? (m_->rig_->state.vfo_list & RIG_VFO_A ? RIG_VFO_A : RIG_VFO_MAIN)
-                                         : (m_->rig_->state.vfo_list & RIG_VFO_B ? RIG_VFO_B : RIG_VFO_SUB)
+                                         ? (HAMLIB_STATE(m_->rig_.data())->vfo_list & RIG_VFO_A ? RIG_VFO_A : RIG_VFO_MAIN)
+                                         : (HAMLIB_STATE(m_->rig_.data())->vfo_list & RIG_VFO_B ? RIG_VFO_B : RIG_VFO_SUB)
                                          , &f), tr ("getting other VFO frequency"));
           f = std::round (f);
           CAT_TRACE ("rig_get_freq other VFO=" << f);
@@ -1214,7 +1230,7 @@ void HamlibTransceiver::do_poll ()
         }
     }
 
-  if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt && rig_get_function_ptr (m_->model_, RIG_FUNCTION_GET_PTT))
+  if (RIG_PTT_NONE != HAMLIB_PTTPORT(m_->rig_.data())->type.ptt && rig_get_function_ptr (m_->model_, RIG_FUNCTION_GET_PTT))
   {
     ptt_t p;
     auto rc = rig_get_ptt (m_->rig_.data (), RIG_VFO_CURR, &p);
@@ -1284,7 +1300,7 @@ void HamlibTransceiver::do_ptt (bool on)
     CAT_TRACE ("PTT: " << on << " " << state () << " reversed=" << m_->reversed_);
   if (on)
     {
-       if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt)
+      if (RIG_PTT_NONE != HAMLIB_PTTPORT(m_->rig_.data())->type.ptt)
         {
           ptt_on_ = true;
           CAT_TRACE ("rig_set_ptt PTT=true");
@@ -1296,7 +1312,7 @@ void HamlibTransceiver::do_ptt (bool on)
     }
   else
     {
-      if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt)
+      if (RIG_PTT_NONE != HAMLIB_PTTPORT(m_->rig_.data())->type.ptt)
         {
           ptt_on_ = false;
           CAT_TRACE ("rig_set_ptt PTT=false");
@@ -1313,7 +1329,7 @@ void HamlibTransceiver::do_tune (bool on)
   CAT_TRACE ("Tune: " << on << " " << state ());
   if (on)
     {
-       if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt)
+      if (RIG_PTT_NONE != HAMLIB_PTTPORT(m_->rig_.data())->type.ptt)
         {
           update_PTT (true); // we'll change the PTT button while we do this
           CAT_TRACE ("rig_vfo_opt RIG_VFO_OP_TUNE=" << on);
@@ -1325,7 +1341,7 @@ void HamlibTransceiver::do_tune (bool on)
 #if 0
   else // do we need to be able to turn PTT off on anybody?
     {
-      if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt)
+      if (RIG_PTT_NONE != HAMLIB_PTTPORT(m_->rig_.data())->type.ptt)
         {
           ptt_on_ = false;
           CAT_TRACE ("rig_set_ptt PTT=false");

--- a/Transceiver/HamlibTransceiver.cpp
+++ b/Transceiver/HamlibTransceiver.cpp
@@ -20,19 +20,19 @@
 #define HAMLIB_CACHE_ALL CACHE_ALL
 #endif
 
-//#if HAVE_HAMLIB_PORT_H
+#if HAVE_HAMLIB_PORT_H
 #include <hamlib/port.h>
-//#endif
-//#if HAVE_HAMLIB_RIG_STATE_H
+#endif
+#if HAVE_HAMLIB_RIG_STATE_H
 #include <hamlib/rig_state.h>
-//#endif
+#endif
 
 /* Should only be needed to compile with Hamlib < 4.5 */
 #ifndef HAMLIB_STATE
-#  define HAMLIB_STATE(x) (&(x).data().state)
+#  define HAMLIB_STATE(x) (&((x).data().state))
 #endif
 #ifndef HAMLIB_PTTPORT
-#  define HAMLIB_PTTPORT(x) (&(x).data().state.pttport)
+#  define HAMLIB_PTTPORT(x) (&((x).data().state.pttport))
 #endif
 
 namespace

--- a/lib/rig_control.c
+++ b/lib/rig_control.c
@@ -60,10 +60,13 @@ int rigOpen(int verbose, rig_model_t my_model, const char* rig_file,
   }
 
   if (rig_file)
-    strncpy(my_rig->state.rigport.pathname, rig_file, FILPATHLEN - 1);
+    rig_set_conf(my_rig, rig_token_lookup(my_rig, "rig_pathname"), rig_file);
 
-  if (serial_rate!=0)
-    my_rig->state.rigport.parm.serial.rate = serial_rate;
+  if (serial_rate!=0 && my_rig->caps.port_type == RIG_PORT_SERIAL) {
+    char speed_string[12];
+    snprintf(speed_string, sizeof(speed_string), "%d", serial_rate);
+    rig_set_conf(my_rig, rig_token_lookup(my_rig, "serial_speed"), speed_string);
+  }
 
   if (civaddr)
     rig_set_conf(my_rig, rig_token_lookup(my_rig, "civaddr"), civaddr);

--- a/wsjtx_config.h.in
+++ b/wsjtx_config.h.in
@@ -31,6 +31,8 @@ extern "C"  {
 
 #cmakedefine01 HAVE_HAMLIB_OLD_CACHING
 #cmakedefine01 HAVE_HAMLIB_CACHING
+#cmakedefine01 HAVE_HAMLIB_PORT_H
+#cmakedefine01 HAVE_HAMLIB_RIG_STATE_H
 
 #cmakedefine HAVE_STDIO_H 1
 #cmakedefine STDC_HEADERS 1


### PR DESCRIPTION
Patches to adapt WSJT-X to Hamlib 5.0 changes

Use rig_set_conf() for port setup -  remove referencing Hamlib internal structures.
Use new methods/macros to access Hamlib state structures when API functions not adequate.

First two commits allow compilation&execution with either Hamlib 4.7.x or 5.0~git.  Third commit is a non-working attempt to broaden that to include 4.6.x and 4.5.x - so far unsuccessful.

Would this be acceptable (if completed)?  What does this need, as far as style or formatting?

Comments, PLEASE

73 n3gb
