### PR TITLE
fix(superfox): guard zero-energy sync calculations

### DIFF
--- a/lib/superfox/qpc_sync.f90
+++ b/lib/superfox/qpc_sync.f90
@@ -46,6 +46,12 @@ subroutine qpc_sync(crcvd0,fsample,isync,fsync,ftol,f2,t2,snrsync)
     s0=s0+s(i)
     s1=s1+(i-i0)*s(i)
   enddo
+  if(.not. (s0 .gt. 0.0)) then
+     f2=fsync-750.0
+     t2=0.0
+     snrsync=0.0
+     return
+  endif
   delta=s1/s0
   i0=nint(i0+delta)
   f2=i0*df2-750.0
@@ -105,9 +111,22 @@ subroutine qpc_sync(crcvd0,fsample,isync,fsync,ftol,f2,t2,snrsync)
      sp=sp + p(lag)
      sq=sq + p(lag)*p(lag)
   enddo
+  if(nsum .le. 0) then
+     snrsync=0.0
+     return
+  endif
   ave=sp/nsum
-  rms=sqrt(sq/nsum-ave*ave)
-  snrsync=(pmax-ave)/rms
+  var=sq/nsum-ave*ave
+  if(.not. (var .gt. 0.0)) then
+     snrsync=0.0
+     return
+  endif
+  rms=sqrt(var)
+  if(rms .gt. 0.0) then
+     snrsync=(pmax-ave)/rms
+  else
+     snrsync=0.0
+  endif
 
   return
 end subroutine qpc_sync

--- a/lib/superfox/sfox_remove_tone.f90
+++ b/lib/superfox/sfox_remove_tone.f90
@@ -68,6 +68,7 @@ subroutine sfox_remove_tone(c0,fsync)
          s0=s0+s(i)
          s1=s1+(i-i0)*s(i)
       enddo
+      if(.not. (s0 .gt. 0.0)) exit
       delta=s1/s0
       i0=nint(i0+delta)
       f2=i0*df


### PR DESCRIPTION
## Summary

Guard SuperFox tone-removal and QPC sync calculations against degenerate zero-energy input.

These paths estimate tone/sync position by normalizing against local spectral energy. If that energy is zero, the estimate is not meaningful, so the code now leaves tone removal unchanged or reports weak sync instead of dividing by zero.

## Changes

- Skip SuperFox tone removal when local spectral energy is not positive.
- Return `snrsync=0.0` when QPC sync has no usable spectral energy.
- Avoid sync SNR division when the off-peak RMS/variance is zero or invalid.

## Testing

- `cmake --build /private/tmp/wsjtx-asan --target sfrx`
- `sfrx 750 50 /private/tmp/wsjtx-sanitize-run/000000_000000.wav`