### PR TITLE
fix(hrd): bounds-check HRD message parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1085,17 +1085,6 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -fexceptions -frtti")
 
-# MinGW gcc 16.x (MSYS2 rolled forward 2026-05) raises false-positive
-# -Wmaybe-uninitialized on the placement-new'd HRDMessage flexible-array
-# struct in Transceiver/HRDTransceiver.cpp. Demote to a warning on Windows
-# + gcc 16+ until upstream gcc tightens the analysis or HRDMessage is
-# refactored. Scoped narrowly so other platforms keep -Werror discipline.
-if (WIN32
-    AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-    AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16.0")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=maybe-uninitialized")
-endif ()
-
 if (NOT APPLE)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pragmas")
   if (${OPENMP_FOUND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ set (wsjt_qt_CXXSRCS
   Transceiver/PollingTransceiver.cpp
   Transceiver/HamlibTransceiver.cpp
   Transceiver/TCITransceiver.cpp
+  Transceiver/HRDMessage.cpp
   Transceiver/HRDTransceiver.cpp
   Transceiver/DXLabSuiteCommanderTransceiver.cpp
   Network/NetworkMessage.cpp
@@ -1265,6 +1266,7 @@ if (WSJT_GENERATE_DOCS)
   add_subdirectory (doc)
 endif (WSJT_GENERATE_DOCS)
 if (EXISTS ${CMAKE_SOURCE_DIR}/tests AND IS_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+  enable_testing ()
   add_subdirectory (tests)
 endif ()
 

--- a/Transceiver/HRDMessage.cpp
+++ b/Transceiver/HRDMessage.cpp
@@ -1,0 +1,132 @@
+#include "Transceiver/HRDMessage.hpp"
+
+#include <QVector>
+
+namespace
+{
+  int constexpr header_size_value = 16;
+  int constexpr max_message_size_value = 1024 * 1024;
+  quint32 constexpr magic_1_value = 0x1234ABCD;
+  quint32 constexpr magic_2_value = 0xABCD1234;
+
+  void append_u32_le (QByteArray * bytes, quint32 value)
+  {
+    bytes->append (static_cast<char> (value & 0xffu));
+    bytes->append (static_cast<char> ((value >> 8) & 0xffu));
+    bytes->append (static_cast<char> ((value >> 16) & 0xffu));
+    bytes->append (static_cast<char> ((value >> 24) & 0xffu));
+  }
+
+  quint32 read_u32_le (QByteArray const& bytes, int offset)
+  {
+    return static_cast<quint32> (static_cast<quint8> (bytes[offset]))
+      | (static_cast<quint32> (static_cast<quint8> (bytes[offset + 1])) << 8)
+      | (static_cast<quint32> (static_cast<quint8> (bytes[offset + 2])) << 16)
+      | (static_cast<quint32> (static_cast<quint8> (bytes[offset + 3])) << 24);
+  }
+
+  HRDMessage::ParseResult valid_partial (int required_size)
+  {
+    return {true, false, required_size, {}, {}};
+  }
+
+  HRDMessage::ParseResult invalid (QString const& error)
+  {
+    return {false, false, 0, {}, error};
+  }
+}
+
+namespace HRDMessage
+{
+  int header_size ()
+  {
+    return header_size_value;
+  }
+
+  int max_message_size ()
+  {
+    return max_message_size_value;
+  }
+
+  QByteArray make (QString const& payload)
+  {
+    QByteArray message;
+    auto const payload_units = payload.size () + 1;
+    auto const payload_bytes = payload_units * 2;
+    auto const message_size = header_size_value + payload_bytes;
+
+    append_u32_le (&message, static_cast<quint32> (message_size));
+    append_u32_le (&message, magic_1_value);
+    append_u32_le (&message, magic_2_value);
+    append_u32_le (&message, 0u);
+
+    auto const utf16 = payload.utf16 ();
+    for (int i = 0; i != payload_units; ++i)
+      {
+        auto const unit = static_cast<quint16> (utf16[i]);
+        message.append (static_cast<char> (unit & 0xffu));
+        message.append (static_cast<char> ((unit >> 8) & 0xffu));
+      }
+
+    return message;
+  }
+
+  ParseResult parse (QByteArray const& message)
+  {
+    if (message.size () < header_size_value)
+      {
+        return valid_partial (header_size_value);
+      }
+
+    auto const message_size = read_u32_le (message, 0);
+    auto const magic_1 = read_u32_le (message, 4);
+    auto const magic_2 = read_u32_le (message, 8);
+
+    if (magic_1 != magic_1_value || magic_2 != magic_2_value)
+      {
+        return invalid ("invalid magic values");
+      }
+
+    if (message_size < static_cast<quint32> (header_size_value))
+      {
+        return invalid ("message size is smaller than the header");
+      }
+
+    if (message_size > static_cast<quint32> (max_message_size_value))
+      {
+        return invalid ("message size is too large");
+      }
+
+    if (message.size () < static_cast<int> (message_size))
+      {
+        return valid_partial (static_cast<int> (message_size));
+      }
+
+    auto const payload_bytes = static_cast<int> (message_size) - header_size_value;
+    if (payload_bytes < 2)
+      {
+        return invalid ("payload is missing the terminator");
+      }
+
+    if (payload_bytes % 2)
+      {
+        return invalid ("payload is not valid UTF-16");
+      }
+
+    QVector<ushort> payload;
+    payload.reserve (payload_bytes / 2);
+    for (int offset = header_size_value; offset != static_cast<int> (message_size); offset += 2)
+      {
+        payload.append (static_cast<ushort> (
+            static_cast<quint16> (static_cast<quint8> (message[offset]))
+            | (static_cast<quint16> (static_cast<quint8> (message[offset + 1])) << 8)));
+      }
+
+    if (payload.isEmpty () || payload.back () != 0u)
+      {
+        return invalid ("payload is missing the terminator");
+      }
+
+    return {true, true, static_cast<int> (message_size), QString::fromUtf16 (payload.constData (), payload.size () - 1), {}};
+  }
+}

--- a/Transceiver/HRDMessage.hpp
+++ b/Transceiver/HRDMessage.hpp
@@ -1,0 +1,25 @@
+#ifndef HRD_MESSAGE_HPP__
+#define HRD_MESSAGE_HPP__
+
+#include <QByteArray>
+#include <QString>
+
+namespace HRDMessage
+{
+  int header_size ();
+  int max_message_size ();
+
+  struct ParseResult
+  {
+    bool valid;
+    bool complete;
+    int required_size;
+    QString payload;
+    QString error;
+  };
+
+  QByteArray make (QString const& payload);
+  ParseResult parse (QByteArray const& message);
+}
+
+#endif

--- a/Transceiver/HRDTransceiver.cpp
+++ b/Transceiver/HRDTransceiver.cpp
@@ -10,6 +10,7 @@
 #include <QDir>
 
 #include "Network/NetworkServerLookup.hpp"
+#include "Transceiver/HRDMessage.hpp"
 #include "qt_helpers.hpp"
 
 namespace
@@ -29,48 +30,6 @@ void HRDTransceiver::register_transceivers (logger_type *,
 {
   (*registry)[HRD_transceiver_name] = TransceiverFactory::Capabilities (id, TransceiverFactory::Capabilities::network, true, true /* maybe */);
 }
-
-struct HRDMessage
-{
-  // Placement style new overload for outgoing messages that does the
-  // construction too.
-  static void * operator new (size_t size, QString const& payload)
-  {
-    size += sizeof (QChar) * (payload.size () + 1); // space for terminator too
-    HRDMessage * storage (reinterpret_cast<HRDMessage *> (new char[size]));
-    storage->size_ = size ;
-    ushort const * pl (payload.utf16 ());
-    std::copy (pl, pl + payload.size () + 1, storage->payload_); // copy terminator too
-    storage->magic_1_ = magic_1_value_;
-    storage->magic_2_ = magic_2_value_;
-    storage->checksum_ = 0;
-    return storage;
-  }
-
-  // Placement style new overload for incoming messages that does the
-  // construction too.
-  //
-  // No memory allocation here.
-  static void * operator new (size_t /* size */, QByteArray const& message)
-  {
-    // Nasty const_cast here to avoid copying the message buffer.
-    return const_cast<HRDMessage *> (reinterpret_cast<HRDMessage const *> (message.data ()));
-  }
-
-  void operator delete (void * p, size_t)
-  {
-    delete [] reinterpret_cast<char *> (p); // Mirror allocation in operator new above.
-  }
-
-  quint32 size_;
-  qint32 magic_1_;
-  qint32 magic_2_;
-  qint32 checksum_;            // Apparently not used.
-  QChar payload_[0];           // UTF-16 (which is wchar_t on Windows)
-
-  static qint32 constexpr magic_1_value_ = 0x1234ABCD;
-  static qint32 constexpr magic_2_value_ = 0xABCD1234;
-};
 
 HRDTransceiver::HRDTransceiver (logger_type * logger
                                 , std::unique_ptr<TransceiverBase> wrapped
@@ -1063,8 +1022,8 @@ QString HRDTransceiver::send_command (QString const& cmd, bool prepend_context, 
   else
     {
       auto string = prepend_context ? context + cmd : cmd;
-      QScopedPointer<HRDMessage> message {new (string) HRDMessage};
-      if (!write_to_port (reinterpret_cast<char const *> (message.data ()), message->size_))
+      auto message = HRDMessage::make (string);
+      if (!write_to_port (message.constData (), message.size ()))
         {
           CAT_ERROR ("failed to write command" << cmd << "to HRD");
           throw error {
@@ -1080,25 +1039,28 @@ QString HRDTransceiver::send_command (QString const& cmd, bool prepend_context, 
     }
   else
     {
-      HRDMessage const * reply {new (buffer) HRDMessage};
-      if (reply->magic_1_value_ != reply->magic_1_ && reply->magic_2_value_ != reply->magic_2_)
-        {
-          CAT_ERROR (cmd << "invalid reply");
-          throw error {
-            tr ("Ham Radio Deluxe sent an invalid reply to our command \"%1\"")
-              .arg (cmd)
-              };
-        }
-
-      // keep reading until expected size arrives
-      while (buffer.size () - offsetof (HRDMessage, size_) < reply->size_)
+      auto reply = HRDMessage::parse (buffer);
+      while (reply.valid && !reply.complete)
         {
           CAT_TRACE (cmd << "reading more reply data");
           buffer += read_reply (cmd);
-          reply = new (buffer) HRDMessage;
+          if (buffer.size () >= reply.required_size)
+            {
+              reply = HRDMessage::parse (buffer);
+            }
         }
 
-      result = QString {reply->payload_}; // this is not a memory leak (honest!)
+      if (!reply.valid)
+        {
+          CAT_ERROR (cmd << "invalid reply:" << reply.error);
+          throw error {
+            tr ("Ham Radio Deluxe sent an invalid reply to our command \"%1\": %2")
+              .arg (cmd)
+              .arg (reply.error)
+              };
+        }
+
+      result = reply.payload;
     }
   CAT_TRACE (cmd << " ->" << result);
   return result;

--- a/Transceiver/HRDTransceiver.hpp
+++ b/Transceiver/HRDTransceiver.hpp
@@ -5,7 +5,6 @@
 #include <tuple>
 #include <memory>
 
-#include <QScopedPointer>
 #include <QString>
 #include <QStringList>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,3 +21,7 @@ include_directories (${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
 add_executable (test_qt_helpers test_qt_helpers.cpp)
 target_link_libraries (test_qt_helpers wsjt_qt Qt5::Test)
 add_test (test_qt_helpers test_qt_helpers)
+
+add_executable (test_hrd_message test_hrd_message.cpp ../Transceiver/HRDMessage.cpp)
+target_link_libraries (test_hrd_message Qt5::Test)
+add_test (test_hrd_message test_hrd_message)

--- a/tests/test_hrd_message.cpp
+++ b/tests/test_hrd_message.cpp
@@ -1,0 +1,168 @@
+#include <QtTest>
+
+#include "Transceiver/HRDMessage.hpp"
+
+namespace
+{
+  quint32 u32le (QByteArray const& bytes, int offset)
+  {
+    return static_cast<quint32> (static_cast<quint8> (bytes[offset]))
+      | (static_cast<quint32> (static_cast<quint8> (bytes[offset + 1])) << 8)
+      | (static_cast<quint32> (static_cast<quint8> (bytes[offset + 2])) << 16)
+      | (static_cast<quint32> (static_cast<quint8> (bytes[offset + 3])) << 24);
+  }
+
+  void write_u32le (QByteArray * bytes, int offset, quint32 value)
+  {
+    (*bytes)[offset] = static_cast<char> (value & 0xffu);
+    (*bytes)[offset + 1] = static_cast<char> ((value >> 8) & 0xffu);
+    (*bytes)[offset + 2] = static_cast<char> ((value >> 16) & 0xffu);
+    (*bytes)[offset + 3] = static_cast<char> ((value >> 24) & 0xffu);
+  }
+}
+
+class TestHRDMessage final
+  : public QObject
+{
+  Q_OBJECT
+
+private slots:
+  void buildsBinaryMessage ()
+  {
+    auto const message = HRDMessage::make ("get radio");
+
+    QCOMPARE (u32le (message, 0), static_cast<quint32> (message.size ()));
+    QCOMPARE (u32le (message, 4), quint32 (0x1234ABCD));
+    QCOMPARE (u32le (message, 8), quint32 (0xABCD1234));
+    QCOMPARE (u32le (message, 12), quint32 (0));
+    QCOMPARE (message.size (), HRDMessage::header_size () + (QString {"get radio"}.size () + 1) * 2);
+    QCOMPARE (static_cast<quint8> (message[message.size () - 2]), quint8 (0));
+    QCOMPARE (static_cast<quint8> (message[message.size () - 1]), quint8 (0));
+  }
+
+  void parsesValidMessage ()
+  {
+    auto const parsed = HRDMessage::parse (HRDMessage::make ("FTDX-3000"));
+
+    QVERIFY (parsed.valid);
+    QVERIFY (parsed.complete);
+    QCOMPARE (parsed.payload, QString {"FTDX-3000"});
+  }
+
+  void preservesUtf16Payload ()
+  {
+    QString payload {"Rig "};
+    payload.append (QChar {0x00d8});
+
+    auto const parsed = HRDMessage::parse (HRDMessage::make (payload));
+
+    QVERIFY (parsed.valid);
+    QVERIFY (parsed.complete);
+    QCOMPARE (parsed.payload, payload);
+  }
+
+  void usesDeclaredSizeForPayload ()
+  {
+    auto message = HRDMessage::make ("OK");
+    message.append ("ignored");
+
+    auto const parsed = HRDMessage::parse (message);
+
+    QVERIFY (parsed.valid);
+    QVERIFY (parsed.complete);
+    QCOMPARE (parsed.payload, QString {"OK"});
+    QCOMPARE (parsed.required_size, HRDMessage::make ("OK").size ());
+  }
+
+  void roundTripsEmptyPayload ()
+  {
+    auto const parsed = HRDMessage::parse (HRDMessage::make (""));
+
+    QVERIFY (parsed.valid);
+    QVERIFY (parsed.complete);
+    QCOMPARE (parsed.payload, QString {});
+  }
+
+  void reportsPartialHeader ()
+  {
+    auto const parsed = HRDMessage::parse (HRDMessage::make ("OK").left (8));
+
+    QVERIFY (parsed.valid);
+    QVERIFY (!parsed.complete);
+    QCOMPARE (parsed.required_size, HRDMessage::header_size ());
+  }
+
+  void reportsPartialBody ()
+  {
+    auto const message = HRDMessage::make ("OK");
+    auto const parsed = HRDMessage::parse (message.left (message.size () - 1));
+
+    QVERIFY (parsed.valid);
+    QVERIFY (!parsed.complete);
+    QCOMPARE (parsed.required_size, message.size ());
+  }
+
+  void rejectsInvalidMagic1 ()
+  {
+    auto message = HRDMessage::make ("OK");
+    write_u32le (&message, 4, 0);
+
+    auto const parsed = HRDMessage::parse (message);
+
+    QVERIFY (!parsed.valid);
+  }
+
+  void rejectsInvalidMagic2 ()
+  {
+    auto message = HRDMessage::make ("OK");
+    write_u32le (&message, 8, 0);
+
+    auto const parsed = HRDMessage::parse (message);
+
+    QVERIFY (!parsed.valid);
+  }
+
+  void rejectsHeaderSize ()
+  {
+    auto message = HRDMessage::make ("OK");
+    write_u32le (&message, 0, HRDMessage::header_size () - 1);
+
+    auto const parsed = HRDMessage::parse (message);
+
+    QVERIFY (!parsed.valid);
+  }
+
+  void rejectsOversizedMessage ()
+  {
+    auto message = HRDMessage::make ("OK");
+    write_u32le (&message, 0, HRDMessage::max_message_size () + 1);
+
+    auto const parsed = HRDMessage::parse (message);
+
+    QVERIFY (!parsed.valid);
+  }
+
+  void rejectsOddUtf16Payload ()
+  {
+    auto message = HRDMessage::make ("OK");
+    write_u32le (&message, 0, message.size () - 1);
+
+    auto const parsed = HRDMessage::parse (message);
+
+    QVERIFY (!parsed.valid);
+  }
+
+  void rejectsMissingTerminator ()
+  {
+    auto message = HRDMessage::make ("OK");
+    message[message.size () - 2] = 'X';
+
+    auto const parsed = HRDMessage::parse (message);
+
+    QVERIFY (!parsed.valid);
+  }
+};
+
+QTEST_MAIN (TestHRDMessage)
+
+#include "test_hrd_message.moc"


### PR DESCRIPTION
## Summary

Fix HRD v5 message parsing by replacing the raw `HRDMessage` struct overlay with a bounds-checked byte parser.

Besides fixing https://github.com/WSJTX/wsjtx/issues/18, this replaces a parser that had several latent memory safety and correctness bugs: out-of-bounds heap reads on short replies and unterminated payloads, unbounded memory growth from an uncapped `size_` field, a dangling-pointer read in the TCP reassembly loop, and a wrong operator in the magic value check (`&&` instead of `||`).

This patch adds `HRDMessage::make` / `HRDMessage::parse`, validates frames before consuming them, caps declared message size at 1 MB, and keeps the HRD receive loop working from parsed `QByteArray` data instead of raw struct pointers.

## Testing
Added `tests/test_hrd_message.cpp` covering:

- valid message construction and parsing
- partial headers and partial bodies
- invalid magic values
- undersized and oversized declared lengths
- odd UTF-16 payload sizes
- missing terminators
- trailing data after a complete message
- empty and non-ASCII UTF-16 payloads

Build and test verified on macOS (Apple Clang) and Linux x86_64 (GCC 16.1.1, Arch Linux) — the same compiler version that triggers #18.

```text
build/tests/test_hrd_message
ctest --test-dir build --output-on-failure