### PR TITLE
Fix TCI: re-emit transceiver_period after TCI connect

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -1226,6 +1226,16 @@ MainWindow::MainWindow(QDir const& temp_directory, bool multiple,
       ui->outAttenuation->setValue(0);
       ui->outAttenuation->setValue(attVal);
       Q_EMIT m_config.transceiver_volume(m_config.volume());
+      // set_mode() above emits transceiver_period() while the TCI rig is
+      // still offline, so TransceiverBase::set() skips do_period and the
+      // TCITransceiver m_period stays at its 15.0 default. For any mode
+      // with TR != 15 s (FT4, FT4-fast, MSK144, Q65-15, FST4-15, …) that
+      // mismatch makes do_modulator_start compute m_ic > i1 in ~64 % of
+      // UTC seconds, so readAudioData emits silence for the whole TX.
+      // Re-emit here, once TCI is connected. OOB guard matches the
+      // pattern in on_actionFT4_triggered() and friends.
+      if (ui->bandComboBox->currentText() != "OOB")
+        Q_EMIT m_config.transceiver_period(m_TRperiod);
     });
   }
 


### PR DESCRIPTION
set_mode() in the MainWindow constructor emits transceiver_period() while the TCI rig is still offline (TCITransceiver::do_start has not finished). TransceiverBase::set() guards its full state-processing block on `if (requested_.online ())`, so the call never reaches do_period() and TCITransceiver::m_period stays at its 15.0 default.

For any mode whose TR period differs from 15 s (FT4, FT4-fast, MSK144, Q65-15, FST4-15, FT8 SuperFox at m_nsps=1024) do_modulator_start then computes:

    mstr = ms_since_midnight mod (m_period * 1000)  // mod 15000, not 7500
    m_ic = (mstr - delay_ms) * (audioSampleRate / 1000)

and lands ~64 % of UTC seconds with m_ic > i1 = symbolsLength * 4 * m_nsps, so readAudioData's main loop (gated by `m_ic <= i1`) never executes the body and the entire transmission is silence-padded via load(0, samples). Tune is unaffected because its i1 is 9999 * m_nsps (unreachable). FT8 happens to work because its TR period is exactly 15 s — matching the wrong default by coincidence.

Symptom against a TCI server with FT4: panadapter shows transmitter energy but no audio gets to the air; remote receivers see noise. Peak amplitude of the TX_AUDIO_STREAM frames returned in response to TX_CHRONO is exactly 0.0000 across the whole TX.

The existing m_tci_audio QTimer::singleShot at +5 s already re-pushes transceiver_trfrequency and transceiver_volume after TCI connects; add transceiver_period to the same callback. The OOB guard matches the pattern in on_actionFT4_triggered() and the other mode handlers.