### PR TITLE
fix(windows): drop unused OpenMP timer common

### DIFF
--- a/lib/decoder.f90
+++ b/lib/decoder.f90
@@ -23,7 +23,6 @@ subroutine multimode_decoder(ss,id2,params,nfsample)
   use packjt77, only : lcommonft8b,ihash22var,calls12var,calls22var
 
   include 'jt9com.f90'
-  include 'timer_common.inc'
 
   type, extends(jt4_decoder) :: counting_jt4_decoder
      integer :: decoded

--- a/lib/map65_mmdec.f90
+++ b/lib/map65_mmdec.f90
@@ -6,7 +6,6 @@ subroutine map65_mmdec(nutc,id2,nqd,ntrperiod, nsubmode,nfa,nfb,nfqso,   &
   use q65_decode
 
   include 'jt9com.f90'
-  include 'timer_common.inc'
 
   type, extends(q65_decoder) :: counting_q65_decoder
      integer :: decoded


### PR DESCRIPTION
## Summary

Fix the Windows MSYS2 GCC 16 OpenMP build by removing unused `timer_common.inc` includes from `decoder.f90` and `map65_mmdec.f90`.

With GCC 16 on MSYS2, these unused OpenMP `threadprivate` COMMON declarations can emit native TLS assembly (`.tls_common`) that the current assembler rejects. That causes the Windows CI build to fail before packaging.

The includes are not needed in these two files: they call the timer through `timer_module`, but they do not reference the `level` / `onlevel` state or the `timer_private` COMMON block declared by `timer_common.inc`. Removing the includes avoids generating the unused TLS declarations while keeping the OpenMP build path intact.

## Testing

- Verified that `level`, `onlevel`, `timer_private`, and `copyin` are not used
  in `lib/decoder.f90` or `lib/map65_mmdec.f90`.
- Built the OpenMP Fortran library locally on macOS:

```text
cmake --build build --target wsjt_fort_omp -- -j8
```

- Ran the full GitHub Actions CI workflow on fix/windows-gcc16-openmp:
  https://github.com/dchristle/wsjtx/actions/runs/26081308605

The Windows MSYS2 build passed with GCC 16, including the OpenMP Fortran build/tests/etc. The `tls_common` or `unknown pseudo-op` failure signatures no longer appear.

Linux, Linux ARM, macOS, and macOS Intel also passed.