### PR TITLE
Added option to load addititional ADIF files for prior worked colors

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -604,6 +604,7 @@ private:
   Q_SLOT void on_udp_server_line_edit_editingFinished ();
   Q_SLOT void on_save_path_select_push_button_clicked (bool);
   Q_SLOT void on_azel_path_select_push_button_clicked (bool);
+  Q_SLOT void on_extra_adi_path_select_push_button_clicked (bool);
   Q_SLOT void on_calibration_intercept_spin_box_valueChanged (double);
   Q_SLOT void handle_leavingSettings ();
   Q_SLOT void on_calibration_slope_ppm_spin_box_valueChanged (double);
@@ -727,6 +728,7 @@ private:
   QDir save_directory_;
   QDir default_azel_directory_;
   QDir azel_directory_;
+  QString extra_adi_directory_;
 
   QFont font_;
   QFont next_font_;
@@ -1133,6 +1135,7 @@ QStringListModel * Configuration::macros () {return &m_->macros_;}
 QStringListModel const * Configuration::macros () const {return &m_->macros_;}
 QDir Configuration::save_directory () const {return m_->save_directory_;}
 QDir Configuration::azel_directory () const {return m_->azel_directory_;}
+QString Configuration::extra_adi_directory () const {return m_->extra_adi_directory_;}
 QString Configuration::rig_name () const {return m_->rig_params_.rig_name;}
 bool Configuration::AzElExtraLines () const {return m_->AzElExtraLines_;}
 bool Configuration::pwrBandTxMemory () const {return m_->pwrBandTxMemory_;}
@@ -2148,6 +2151,7 @@ void Configuration::impl::initialize_models ()
   if (!ui_->PWR_and_SWR_check_box->isChecked()) ui_->check_SWR_check_box->setEnabled (false);
   ui_->save_path_display_label->setText (save_directory_.absolutePath ());
   ui_->azel_path_display_label->setText (azel_directory_.absolutePath ());
+  ui_->extra_adi_path_display_label->setText (extra_adi_directory_);
   ui_->CW_id_after_73_check_box->setChecked (id_after_73_);
   ui_->tx_QSY_check_box->setChecked (tx_QSY_allowed_);
   ui_->progress_bar_check_box->setChecked (progressBar_red_);
@@ -2488,6 +2492,7 @@ void Configuration::impl::read_settings ()
   RxBandwidth_ = settings_->value ("RxBandwidth", 2500).toInt ();
   save_directory_.setPath (settings_->value ("SaveDir", default_save_directory_.absolutePath ()).toString ());
   azel_directory_.setPath (settings_->value ("AzElDir", default_azel_directory_.absolutePath ()).toString ());
+  extra_adi_directory_ = settings_->value ("ExtraADIDir", QString {}).toString ();
 
   tci_audio_ = settings_->value ("TCIAudio", tci_audio_).toBool ();
 
@@ -2818,6 +2823,7 @@ void Configuration::impl::write_settings ()
   settings_->setValue ("PTTport", rig_params_.ptt_port);
   settings_->setValue ("SaveDir", save_directory_.absolutePath ());
   settings_->setValue ("AzElDir", azel_directory_.absolutePath ());
+  settings_->setValue ("ExtraADIDir", extra_adi_directory_);
   if (!audio_input_device_.isNull ()) {
       settings_->setValue ("SoundInName", audio_input_device_.deviceName ());
       settings_->setValue ("AudioInputChannel", AudioDevice::toString (audio_input_channel_));
@@ -3487,6 +3493,11 @@ void Configuration::impl::accept ()
   bLowSidelobes_ = ui_->rbLowSidelobes->isChecked();
   save_directory_.setPath (ui_->save_path_display_label->text ());
   azel_directory_.setPath (ui_->azel_path_display_label->text ());
+  auto const prev_extra_adi = extra_adi_directory_;
+  extra_adi_directory_ = ui_->extra_adi_path_display_label->text ();
+  if (logbook_ && extra_adi_directory_ != prev_extra_adi) {
+    logbook_->rescan ();
+  }
   enable_VHF_features_ = ui_->enable_VHF_features_check_box->isChecked ();
   decode_at_52s_ = ui_->decode_at_52s_check_box->isChecked ();
   kHz_without_k_ = ui_->kHz_without_k_check_box->isChecked ();
@@ -4529,6 +4540,18 @@ void Configuration::impl::on_azel_path_select_push_button_clicked (bool /* check
   if (fd.exec ()) {
     if (fd.selectedFiles ().size ()) {
       ui_->azel_path_display_label->setText(fd.selectedFiles().at(0));
+    }
+  }
+}
+
+void Configuration::impl::on_extra_adi_path_select_push_button_clicked (bool /* checked */)
+{
+  QFileDialog fd {this, tr ("Additional ADIF Directory"), ui_->extra_adi_path_display_label->text ()};
+  fd.setFileMode (QFileDialog::Directory);
+  fd.setOption (QFileDialog::ShowDirsOnly);
+  if (fd.exec ()) {
+    if (fd.selectedFiles ().size ()) {
+      ui_->extra_adi_path_display_label->setText (fd.selectedFiles ().at (0));
     }
   }
 }

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -255,6 +255,7 @@ public:
   QStringListModel const * macros () const;
   QDir save_directory () const;
   QDir azel_directory () const;
+  QString extra_adi_directory () const;
   QString rig_name () const;
   Type2MsgGen type_2_msg_gen () const;
   bool AzElExtraLines () const;

--- a/Configuration.ui
+++ b/Configuration.ui
@@ -2857,7 +2857,7 @@ Right click for insert and delete options.</string>
             <item>
              <widget class="QLabel" name="label_extra_adi_dir">
               <property name="text">
-               <string>Additional ADIF Directory:</string>
+               <string>Additional ADIF Directory (Recursive):</string>
               </property>
              </widget>
             </item>

--- a/Configuration.ui
+++ b/Configuration.ui
@@ -2852,6 +2852,43 @@ Right click for insert and delete options.</string>
             </property>
            </widget>
           </item>
+          <item row="2" column="0" colspan="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_extra_adi">
+            <item>
+             <widget class="QLabel" name="label_extra_adi_dir">
+              <property name="text">
+               <string>Additional ADIF Directory:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="extra_adi_path_display_label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Path to directory containing additional ADIF (.adi) files to include in worked-before scanning.</string>
+              </property>
+              <property name="placeholderText">
+               <string>(none)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="extra_adi_path_select_push_button">
+              <property name="toolTip">
+               <string>Click to select a directory containing additional ADIF files to scan for worked-before information.</string>
+              </property>
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
           <item row="3" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout_23">
             <item row="1" column="0">

--- a/logbook/WorkedBefore.cpp
+++ b/logbook/WorkedBefore.cpp
@@ -279,9 +279,8 @@ namespace
     return QString {};
   }
 
-  worked_before_database_type loader (QString const& path, AD1CCty const * prefixes)
+  void load_file (QString const& path, AD1CCty const * prefixes, worked_before_database_type& worked)
   {
-    worked_before_database_type worked;
     QFile inputFile {path};
     if (inputFile.exists ())
       {
@@ -359,6 +358,26 @@ namespace
             throw LoaderException (std::runtime_error {QCoreApplication::translate ("WorkedBefore", "Error opening ADIF log file for read: %0").arg (inputFile.errorString ()).toLocal8Bit ()});
           }
       }
+  }
+
+  worked_before_database_type loader (QString const& path, QString const& extra_dir, AD1CCty const * prefixes)
+  {
+    worked_before_database_type worked;
+    load_file (path, prefixes, worked);
+    if (!extra_dir.isEmpty ())
+      {
+        QDir dir {extra_dir};
+        if (dir.exists ())
+          {
+            auto const entries = dir.entryInfoList (QStringList {} << "*.adi" << "*.ADI",
+                                                    QDir::Files | QDir::Readable);
+            for (auto const& entry : entries)
+              {
+                if (entry.absoluteFilePath () != path)
+                  load_file (entry.absoluteFilePath (), prefixes, worked);
+              }
+          }
+      }
     return worked;
   }
 }
@@ -376,7 +395,7 @@ public:
   void reload ()
   {
     prefixes_.reload (configuration_);
-    async_loader_ = QtConcurrent::run (loader, path_, &prefixes_);
+    async_loader_ = QtConcurrent::run (loader, path_, configuration_->extra_adi_directory (), &prefixes_);
     loader_watcher_.setFuture (async_loader_);
   }
 

--- a/logbook/WorkedBefore.cpp
+++ b/logbook/WorkedBefore.cpp
@@ -17,6 +17,7 @@
 #include <QByteArray>
 #include <QStandardPaths>
 #include <QDir>
+#include <QDirIterator>
 #include <QFileInfo>
 #include <QFile>
 #include <QTextStream>
@@ -366,15 +367,16 @@ namespace
     load_file (path, prefixes, worked);
     if (!extra_dir.isEmpty ())
       {
-        QDir dir {extra_dir};
-        if (dir.exists ())
+        if (QDir {extra_dir}.exists ())
           {
-            auto const entries = dir.entryInfoList (QStringList {} << "*.adi" << "*.ADI",
-                                                    QDir::Files | QDir::Readable);
-            for (auto const& entry : entries)
+            QDirIterator it {extra_dir, QStringList {} << "*.adi" << "*.ADI",
+                             QDir::Files | QDir::Readable,
+                             QDirIterator::Subdirectories};
+            while (it.hasNext ())
               {
-                if (entry.absoluteFilePath () != path)
-                  load_file (entry.absoluteFilePath (), prefixes, worked);
+                auto const file_path = it.next ();
+                if (file_path != path)
+                  load_file (file_path, prefixes, worked);
               }
           }
       }


### PR DESCRIPTION
This option allows users to keep their logbooks in a separate directory and WSJT-X can load them for prior worked color marking.  This is recursive and will work down the tree.  This allows hams to keep multiple adif files around.  Previously I would copy and paste contacts into wsjtx_log.adi which was kinda annoying.  I can download my logbook from QRZ into my Downloads folder, then point this option that way and it will find those files automatically.