### PR TITLE
Fix format-security warning

### DIFF
--- a/map65/libm65/tmoonsub.c
+++ b/map65/libm65/tmoonsub.c
@@ -36,7 +36,7 @@ void tmoonsub_(double *day, double *glat, double *glong, double *moonalt,
    double *mrv, double *l, double *b, double *paxis);
 
 static const char
-*usage = "  Usage: tmoon date[yyyymm] timz[+/-h.hh] long[+/-dddmm] lat[+/-ddmm]\n"
+usage[] = "  Usage: tmoon date[yyyymm] timz[+/-h.hh] long[+/-dddmm] lat[+/-ddmm]\n"
             "example: tmoon 200009 0 -00155 5230\n";
 
 /*


### PR DESCRIPTION
map65/libm65/tmoonsub.c: In function ‘getargs’:
map65/libm65/tmoonsub.c:59:5: error: format not a string literal and no format arguments [-Werror=format-security]
   59 |     fprintf(stderr, usage);
      |     ^~~~~~~