### PR TITLE
Add colorblind-accessible decode highlighting palettes

### DIFF
--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -148,6 +148,7 @@
 #include <QSound>
 #include <QDialog>
 #include <QAction>
+#include <QMenu>
 #include <QFileDialog>
 #include <QDir>
 #include <QTemporaryFile>
@@ -616,6 +617,7 @@ private:
   Q_SLOT void on_cbHighDPI_clicked(bool checked);
   Q_SLOT void on_reset_highlighting_to_defaults_push_button_clicked (bool);
   Q_SLOT void on_reset_highlighting_to_defaults2_push_button_clicked (bool);
+  void apply_highlighting_preset (QString const& description, DecodeHighlightingModel::HighlightItems const& preset);
   Q_SLOT void on_rescan_log_push_button_clicked (bool);
   Q_SLOT void on_CTY_download_button_clicked (bool);
   Q_SLOT void on_CALL3_download_button_clicked (bool);
@@ -1812,6 +1814,30 @@ Configuration::impl::impl (Configuration * self, QNetworkAccessManager * network
   , default_audio_output_device_selected_ {false}
 {
   ui_->setupUi (this);
+
+  {
+    auto accessibility_menu = new QMenu {ui_->apply_accessibility_palette_push_button};
+
+    auto deuteranopia_action = accessibility_menu->addAction (tr ("Red-Green safe (Deuteranopia/Protanopia)"));
+    connect (deuteranopia_action, &QAction::triggered, this, [this] {
+        apply_highlighting_preset (tr ("Red-Green safe (Deuteranopia/Protanopia)")
+                                   , DecodeHighlightingModel::default_items_deuteranopia ());
+      });
+
+    auto tritanopia_action = accessibility_menu->addAction (tr ("Blue-Yellow safe (Tritanopia)"));
+    connect (tritanopia_action, &QAction::triggered, this, [this] {
+        apply_highlighting_preset (tr ("Blue-Yellow safe (Tritanopia)")
+                                   , DecodeHighlightingModel::default_items_tritanopia ());
+      });
+
+    auto high_contrast_action = accessibility_menu->addAction (tr ("High contrast"));
+    connect (high_contrast_action, &QAction::triggered, this, [this] {
+        apply_highlighting_preset (tr ("High contrast")
+                                   , DecodeHighlightingModel::default_items_high_contrast ());
+      });
+
+    ui_->apply_accessibility_palette_push_button->setMenu (accessibility_menu);
+  }
 
   {
     // Make sure the default save directory exists
@@ -3692,6 +3718,16 @@ void Configuration::impl::on_reset_highlighting_to_defaults_push_button_clicked 
                                                     , tr ("Reset all decode highlighting and priorities to Default 1 values")))
     {
       next_decode_highlighing_model_.items (DecodeHighlightingModel::default_items ());
+    }
+}
+
+void Configuration::impl::apply_highlighting_preset (QString const& description, DecodeHighlightingModel::HighlightItems const& preset)
+{
+  if (MessageBox::Yes == MessageBox::query_message (this
+                                                    , tr ("Reset Decode Highlighting")
+                                                    , tr ("Reset all decode highlighting and priorities to %1 values").arg (description)))
+    {
+      next_decode_highlighing_model_.items (preset);
     }
 }
 

--- a/Configuration.ui
+++ b/Configuration.ui
@@ -2804,6 +2804,16 @@ Right click for insert and delete options.</string>
              </widget>
             </item>
             <item>
+             <widget class="QPushButton" name="apply_accessibility_palette_push_button">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Push to choose a colorblind or low-vision friendly preset for all highlight items above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Apply Accessibility Palette</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QPushButton" name="rescan_log_push_button">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to scan the wsjtx_log.adi ADIF file again for worked before information&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/doc/user_guide/en/settings-colors.adoc
+++ b/doc/user_guide/en/settings-colors.adoc
@@ -15,6 +15,12 @@ image::colors.png[align="center",alt="Colors Screen"]
 * Press the *Reset Highlighting* button to reset all of the color
   settings to default values.
 
+* Press the *Apply Accessibility Palette* button to choose a
+  colorblind or low-vision friendly color preset: *Red-Green safe
+  (Deuteranopia/Protanopia)*, *Blue-Yellow safe (Tritanopia)*, or
+  *High contrast*. Like *Reset Highlighting*, this replaces all
+  current color settings after you confirm the change.
+
 * Check *Highlight by Mode* if you wish worked-before status to be per
   <<INTRO,mode>>.
 

--- a/models/DecodeHighlightingModel.cpp
+++ b/models/DecodeHighlightingModel.cpp
@@ -27,6 +27,9 @@ public:
 
   HighlightItems static const defaults_;
   HighlightItems static const defaults2_;
+  HighlightItems static const deuteranopia_;
+  HighlightItems static const tritanopia_;
+  HighlightItems static const high_contrast_;
   HighlightItems data_;
   QFont font_;
 };
@@ -67,6 +70,74 @@ QList<DecodeHighlightingModel::HighlightInfo> const DecodeHighlightingModel::imp
   , {Highlight::CallBand, true, {{0xaa, 0x00, 0x00}}, {{0xb4, 0xff, 0xb4}}}
   , {Highlight::CQ, true, {{0xaa, 0x00, 0x00}}, {{0xc3, 0xc3, 0xc3}}}
   , {Highlight::Tx, true, {Qt::black}, {{0xff, 0xa5, 0xc6}}}
+};
+
+// Backgrounds drawn from the Okabe-Ito categorical palette, the
+// standard reference palette for deuteranopia/protanopia
+// accessibility. Foreground is black or white, whichever contrasts
+// more with that item's background.
+QList<DecodeHighlightingModel::HighlightInfo> const DecodeHighlightingModel::impl::deuteranopia_ = {
+  {Highlight::MyCall, true, {Qt::white}, {{0xd5, 0x5e, 0x00}}}
+  , {Highlight::Continent, true, {Qt::white}, {{0x00, 0x72, 0xb2}}}
+  , {Highlight::ContinentBand, true, {Qt::black}, {{0xa8, 0xcc, 0xe3}}}
+  , {Highlight::CQZone, true, {Qt::black}, {{0xe6, 0x9f, 0x00}}}
+  , {Highlight::CQZoneBand, true, {Qt::black}, {{0xf5, 0xd9, 0x99}}}
+  , {Highlight::ITUZone, false, {Qt::black}, {{0x56, 0xb4, 0xe9}}}
+  , {Highlight::ITUZoneBand, false, {Qt::black}, {{0xbe, 0xe3, 0xf5}}}
+  , {Highlight::DXCC, true, {Qt::black}, {{0xcc, 0x79, 0xa7}}}
+  , {Highlight::DXCCBand, true, {Qt::black}, {{0xe8, 0xbf, 0xd6}}}
+  , {Highlight::Grid, false, {Qt::white}, {Qt::black}}
+  , {Highlight::GridBand, false, {Qt::black}, {{0xcc, 0xcc, 0xcc}}}
+  , {Highlight::Call, false, {Qt::black}, {{0x99, 0x99, 0x99}}}
+  , {Highlight::CallBand, false, {Qt::black}, {{0xdd, 0xdd, 0xdd}}}
+  , {Highlight::LotW, false, {{0x00, 0x55, 0x44}}, {}}
+  , {Highlight::CQ, true, {Qt::white}, {{0x00, 0x9e, 0x73}}}
+  , {Highlight::Tx, true, {Qt::black}, {{0xf0, 0xe4, 0x42}}}
+};
+
+// Backgrounds drawn from the red/green/orange/purple axis, which
+// tritanopia does not impair, avoiding blue vs. yellow as a
+// differentiator between categories.
+QList<DecodeHighlightingModel::HighlightInfo> const DecodeHighlightingModel::impl::tritanopia_ = {
+  {Highlight::MyCall, true, {Qt::white}, {{0xe4, 0x1a, 0x1c}}}
+  , {Highlight::Continent, true, {Qt::black}, {{0xf7, 0x81, 0xbf}}}
+  , {Highlight::ContinentBand, true, {Qt::black}, {{0xfc, 0xe0, 0xef}}}
+  , {Highlight::CQZone, true, {Qt::white}, {{0xa6, 0x56, 0x28}}}
+  , {Highlight::CQZoneBand, true, {Qt::black}, {{0xe3, 0xc6, 0xb3}}}
+  , {Highlight::ITUZone, false, {Qt::white}, {{0xb0, 0x30, 0x60}}}
+  , {Highlight::ITUZoneBand, false, {Qt::black}, {{0xe8, 0xb9, 0xc7}}}
+  , {Highlight::DXCC, true, {Qt::white}, {{0x98, 0x4e, 0xa3}}}
+  , {Highlight::DXCCBand, true, {Qt::black}, {{0xe0, 0xc6, 0xe6}}}
+  , {Highlight::Grid, false, {Qt::black}, {{0x99, 0x99, 0x99}}}
+  , {Highlight::GridBand, false, {Qt::black}, {{0xdd, 0xdd, 0xdd}}}
+  , {Highlight::Call, false, {Qt::black}, {{0xfd, 0xbf, 0x6f}}}
+  , {Highlight::CallBand, false, {Qt::black}, {{0xfd, 0xe9, 0xd0}}}
+  , {Highlight::LotW, false, {{0x6e, 0x14, 0x23}}, {}}
+  , {Highlight::CQ, true, {Qt::black}, {{0x4d, 0xaf, 0x4a}}}
+  , {Highlight::Tx, true, {Qt::black}, {{0xff, 0x7f, 0x00}}}
+};
+
+// Strongly saturated, high-luminance-difference colors. "Band"
+// variants use a darker/desaturated shade of the base category's
+// hue rather than a pale tint, since pale tints wash out for low
+// vision.
+QList<DecodeHighlightingModel::HighlightInfo> const DecodeHighlightingModel::impl::high_contrast_ = {
+  {Highlight::MyCall, true, {Qt::white}, {{0xff, 0x00, 0x00}}}
+  , {Highlight::Continent, true, {Qt::black}, {{0xff, 0x80, 0x00}}}
+  , {Highlight::ContinentBand, true, {Qt::white}, {{0x99, 0x50, 0x00}}}
+  , {Highlight::CQZone, true, {Qt::white}, {{0x00, 0x40, 0xff}}}
+  , {Highlight::CQZoneBand, true, {Qt::white}, {{0x00, 0x29, 0x66}}}
+  , {Highlight::ITUZone, false, {Qt::white}, {{0x00, 0x80, 0x80}}}
+  , {Highlight::ITUZoneBand, false, {Qt::white}, {{0x00, 0x4d, 0x4d}}}
+  , {Highlight::DXCC, true, {Qt::white}, {{0xcc, 0x00, 0xcc}}}
+  , {Highlight::DXCCBand, true, {Qt::white}, {{0x7a, 0x00, 0x7a}}}
+  , {Highlight::Grid, false, {Qt::white}, {{0x66, 0x66, 0x66}}}
+  , {Highlight::GridBand, false, {Qt::white}, {{0x33, 0x33, 0x33}}}
+  , {Highlight::Call, false, {Qt::white}, {{0xd6, 0x00, 0x6d}}}
+  , {Highlight::CallBand, false, {Qt::white}, {{0x80, 0x00, 0x41}}}
+  , {Highlight::LotW, false, {{0x00, 0x1a, 0x66}}, {}}
+  , {Highlight::CQ, true, {Qt::white}, {{0x00, 0xa0, 0x00}}}
+  , {Highlight::Tx, true, {Qt::black}, {{0xff, 0xff, 0x00}}}
 };
 
 bool operator == (DecodeHighlightingModel::HighlightInfo const& lhs, DecodeHighlightingModel::HighlightInfo const& rhs)
@@ -157,6 +228,21 @@ auto DecodeHighlightingModel::default_items () -> HighlightItems const&
 auto DecodeHighlightingModel::default_items2 () -> HighlightItems const&
 {
   return impl::defaults2_;
+}
+
+auto DecodeHighlightingModel::default_items_deuteranopia () -> HighlightItems const&
+{
+  return impl::deuteranopia_;
+}
+
+auto DecodeHighlightingModel::default_items_tritanopia () -> HighlightItems const&
+{
+  return impl::tritanopia_;
+}
+
+auto DecodeHighlightingModel::default_items_high_contrast () -> HighlightItems const&
+{
+  return impl::high_contrast_;
 }
 
 auto DecodeHighlightingModel::items () const -> HighlightItems const&

--- a/models/DecodeHighlightingModel.hpp
+++ b/models/DecodeHighlightingModel.hpp
@@ -40,6 +40,9 @@ public:
   // access to raw items nd default items
   static HighlightItems const& default_items ();
   static HighlightItems const& default_items2 ();
+  static HighlightItems const& default_items_deuteranopia ();
+  static HighlightItems const& default_items_tritanopia ();
+  static HighlightItems const& default_items_high_contrast ();
   HighlightItems const& items () const;
   void items (HighlightItems const&);
 


### PR DESCRIPTION
## What this does
Adds three predefined, colorblind/low-vision-friendly color presets for the
Decode Highlighting feature (Configuration → Colors tab): Red-Green safe
(Deuteranopia/Protanopia), Blue-Yellow safe (Tritanopia), and High contrast.
A new "Apply Accessibility Palette" button + dropdown menu applies them,
reusing the existing confirm-then-apply flow already used by "Reset
Highlighting to Default 1/2".

## Why
While helping a family member (also a licensed ham) set up WSJT-X, I
realized the color-coded decode highlighting wasn't helping him due to a
color vision deficiency. It made me think about how many ham operators
might be in the same situation, quietly working around a UI that assumes
everyone sees colors the same way.

WSJT-X already lets you customize every highlight color by hand, but
picking colors that actually work for a given color vision deficiency
takes some know-how most users don't have. Having a few vetted presets
ready to go means someone can just pick the one that matches their
situation instead of having to research and hand-pick colors themselves.
## Tested on
macOS (Homebrew Qt5/Hamlib/FFTW/Boost toolchain), full app build clean,
manually verified in the running app: applying each preset, confirmation
dialog, colors updating in the list view, persistence across restart.

## Screenshots

<img width="967" height="344" alt="SCR-20260723-jnxd" src="https://github.com/user-attachments/assets/95a1afbb-2476-466b-9ace-16d02e1e83d8" />

<img width="970" height="504" alt="SCR-20260723-joac" src="https://github.com/user-attachments/assets/af9cfc60-11b7-432a-a62d-be9b3815256d" />

<img width="967" height="463" alt="SCR-20260723-jobz" src="https://github.com/user-attachments/assets/801528df-92f1-4e01-8e01-ed13d7f34ed4" />

<img width="965" height="470" alt="SCR-20260723-jodv" src="https://github.com/user-attachments/assets/b9cd43fc-21e3-41bd-ba2b-0e45ceb54620" />

---
Happy to iterate on this — open to feedback on the color choices, the UI
placement, or the overall approach, and glad to make updates as needed.

73