### PR TITLE
Make activity windows sticky-scroll and add scroll-to-bottom button

### DIFF
--- a/widgets/displaytext.cpp
+++ b/widgets/displaytext.cpp
@@ -92,12 +92,12 @@ DisplayText::DisplayText(QWidget *parent)
   scroll_to_bottom_button_->setCursor (Qt::ArrowCursor);
   scroll_to_bottom_button_->setToolTip (tr ("Scroll to the latest entry"));
   scroll_to_bottom_button_->hide ();
-  connect (scroll_to_bottom_button_, &QToolButton::clicked, this, &DisplayText::scroll_to_bottom);
+  connect (scroll_to_bottom_button_, &QToolButton::clicked, this, &DisplayText::scrollToBottom);
   connect (verticalScrollBar (), &QScrollBar::valueChanged, this, [this] (int) {
-      update_scroll_to_bottom_button ();
+      updateScrollToBottomButton ();
     });
   connect (verticalScrollBar (), &QScrollBar::rangeChanged, this, [this] (int, int) {
-      update_scroll_to_bottom_button ();
+      updateScrollToBottomButton ();
     });
 }
 
@@ -105,10 +105,14 @@ void DisplayText::erase ()
 {
   clear ();
   last_auto_scroll_position_ = verticalScrollBar ()->value ();
-  update_scroll_to_bottom_button ();
+  updateScrollToBottomButton ();
   Q_EMIT erased ();
 }
 
+//
+// Return true while the view is still tracking new entries, i.e. parked at the
+// bottom or at the position to which we last automatically scrolled.
+//
 bool DisplayText::following () const
 {
   auto const * vertical_scroll_bar = verticalScrollBar ();
@@ -118,15 +122,21 @@ bool DisplayText::following () const
     || vertical_scroll_bar->value () == last_auto_scroll_position_;
 }
 
-void DisplayText::scroll_to_bottom ()
+//
+// Scroll the view to the latest entry at the bottom and resume tracking.
+//
+void DisplayText::scrollToBottom ()
 {
   auto * vertical_scroll_bar = verticalScrollBar ();
   vertical_scroll_bar->setValue (vertical_scroll_bar->maximum ());
   last_auto_scroll_position_ = vertical_scroll_bar->value ();
-  update_scroll_to_bottom_button ();
+  updateScrollToBottomButton ();
 }
 
-void DisplayText::update_scroll_to_bottom_button ()
+//
+// Update position, size, and visibility of the scroll-to-bottom button.
+//
+void DisplayText::updateScrollToBottomButton ()
 {
   auto const * vertical_scroll_bar = verticalScrollBar ();
   // park the button in the bottom-right corner of the viewport, sized to fit
@@ -148,10 +158,13 @@ void DisplayText::update_scroll_to_bottom_button ()
   scroll_to_bottom_button_->setVisible (wanted);
 }
 
+//
+// Handle resize events to reposition the scroll-to-bottom button in viewport.
+//
 void DisplayText::resizeEvent (QResizeEvent * e)
 {
   QTextEdit::resizeEvent (e);
-  update_scroll_to_bottom_button ();
+  updateScrollToBottomButton ();
 }
 
 void DisplayText::setContentFont(QFont const& font)
@@ -178,7 +191,7 @@ void DisplayText::setContentFont(QFont const& font)
       // this counts as an automatic scroll, so keep following from here
       last_auto_scroll_position_ = verticalScrollBar ()->value ();
     }
-  update_scroll_to_bottom_button ();
+  updateScrollToBottomButton ();
 }
 
 void DisplayText::mouseDoubleClickEvent(QMouseEvent *e)
@@ -328,7 +341,7 @@ void DisplayText::insertText(QString const& text, QColor bg, QColor fg
       vertical_scroll_bar->setValue (vertical_scroll_bar->value ()
                                      + cursorRect (anchor).top () - anchor_offset);
     }
-  update_scroll_to_bottom_button ();
+  updateScrollToBottomButton ();
 }
 
 void DisplayText::extend_vertical_scrollbar (int min, int max)
@@ -380,7 +393,7 @@ void DisplayText::new_period ()
       verticalScrollBar ()->setSliderPosition (verticalScrollBar ()->maximum ());
       last_auto_scroll_position_ = verticalScrollBar ()->value ();
     }
-  update_scroll_to_bottom_button ();
+  updateScrollToBottomButton ();
 }
 
 QString DisplayText::appendWorkedB4 (QString message, QString call, QString const& grid,

--- a/widgets/displaytext.cpp
+++ b/widgets/displaytext.cpp
@@ -19,6 +19,8 @@
 #include <QListIterator>
 #include <QRegularExpression>
 #include <QScrollBar>
+#include <QToolButton>
+#include <QResizeEvent>
 
 #include "Configuration.hpp"
 #include "Decoder/decodedtext.h"
@@ -52,6 +54,8 @@ DisplayText::DisplayText(QWidget *parent)
   , erase_action_ {new QAction {tr ("&Erase"), this}}
   , high_volume_ {false}
   , modified_vertical_scrollbar_max_ {-1}
+  , scroll_to_bottom_button_ {new QToolButton {viewport ()}}
+  , last_auto_scroll_position_ {0}
 {
   setReadOnly (true);
   setUndoRedoEnabled (false);
@@ -70,12 +74,84 @@ DisplayText::DisplayText(QWidget *parent)
       delete menu;
     });
   connect (erase_action_, &QAction::triggered, this, &DisplayText::erase);
+
+  // floating "jump to latest" button in the bottom-right corner of the text
+  // area, shown only while the user has scrolled away from the newest entry.
+  // It is parented to the viewport so its placement never depends on the
+  // vertical scroll bar's (unreliable) geometry.
+  scroll_to_bottom_button_->setText (tr ("Return to live activity"));
+  scroll_to_bottom_button_->setToolButtonStyle (Qt::ToolButtonTextOnly);
+  scroll_to_bottom_button_->setAutoRaise (false);
+  // bright red chip with white text so it is unmistakable against the decodes
+  scroll_to_bottom_button_->setStyleSheet (
+      QStringLiteral ("QToolButton { background: #d00000; color: #ffffff;"
+                      " border: 1px solid #8b0000; border-radius: 3px;"
+                      " font-weight: bold; padding: 1px 8px; }"
+                      "QToolButton:hover { background: #ef2b2b; }"));
+  scroll_to_bottom_button_->setFocusPolicy (Qt::NoFocus);
+  scroll_to_bottom_button_->setCursor (Qt::ArrowCursor);
+  scroll_to_bottom_button_->setToolTip (tr ("Scroll to the latest entry"));
+  scroll_to_bottom_button_->hide ();
+  connect (scroll_to_bottom_button_, &QToolButton::clicked, this, &DisplayText::scroll_to_bottom);
+  connect (verticalScrollBar (), &QScrollBar::valueChanged, this, [this] (int) {
+      update_scroll_to_bottom_button ();
+    });
+  connect (verticalScrollBar (), &QScrollBar::rangeChanged, this, [this] (int, int) {
+      update_scroll_to_bottom_button ();
+    });
 }
 
 void DisplayText::erase ()
 {
   clear ();
+  last_auto_scroll_position_ = verticalScrollBar ()->value ();
+  update_scroll_to_bottom_button ();
   Q_EMIT erased ();
+}
+
+bool DisplayText::following () const
+{
+  auto const * vertical_scroll_bar = verticalScrollBar ();
+  // either parked at the very bottom, or still exactly where we last
+  // scrolled to automatically - anything else means the user has taken over
+  return vertical_scroll_bar->value () >= vertical_scroll_bar->maximum ()
+    || vertical_scroll_bar->value () == last_auto_scroll_position_;
+}
+
+void DisplayText::scroll_to_bottom ()
+{
+  auto * vertical_scroll_bar = verticalScrollBar ();
+  vertical_scroll_bar->setValue (vertical_scroll_bar->maximum ());
+  last_auto_scroll_position_ = vertical_scroll_bar->value ();
+  update_scroll_to_bottom_button ();
+}
+
+void DisplayText::update_scroll_to_bottom_button ()
+{
+  auto const * vertical_scroll_bar = verticalScrollBar ();
+  // park the button in the bottom-right corner of the viewport, sized to fit
+  // its label so it stays a large, easy target while the scroll bar is dragged
+  auto const hint = scroll_to_bottom_button_->sizeHint ();
+  auto const button_height = qMax (hint.height (), qMax (20, vertical_scroll_bar->sizeHint ().width ()));
+  auto const button_width = hint.width () + 8;
+  auto const margin = 3;
+  scroll_to_bottom_button_->resize (button_width, button_height);
+  scroll_to_bottom_button_->move (viewport ()->width () - button_width - margin
+                                  , viewport ()->height () - button_height - margin);
+  auto const wanted = vertical_scroll_bar->maximum () > vertical_scroll_bar->minimum ()
+    && !following ();
+  if (wanted)
+    {
+      // keep the button above the decode text after each new insertion
+      scroll_to_bottom_button_->raise ();
+    }
+  scroll_to_bottom_button_->setVisible (wanted);
+}
+
+void DisplayText::resizeEvent (QResizeEvent * e)
+{
+  QTextEdit::resizeEvent (e);
+  update_scroll_to_bottom_button ();
 }
 
 void DisplayText::setContentFont(QFont const& font)
@@ -99,7 +175,10 @@ void DisplayText::setContentFont(QFont const& font)
     {
       setTextCursor (cursor);
       ensureCursorVisible ();
+      // this counts as an automatic scroll, so keep following from here
+      last_auto_scroll_position_ = verticalScrollBar ()->value ();
     }
+  update_scroll_to_bottom_button ();
 }
 
 void DisplayText::mouseDoubleClickEvent(QMouseEvent *e)
@@ -149,6 +228,13 @@ namespace
 void DisplayText::insertText(QString const& text, QColor bg, QColor fg
                              , QString const& call1, QString const& call2, QTextCursor::MoveOperation location)
 {
+  // only chase new entries if the view has not been scrolled away by the user
+  auto const was_following = following ();
+  // remember where the top visible line sits so that trimming of old entries,
+  // or insertion above the view port, does not drag a parked view along
+  auto const anchor = cursorForPosition (QPoint {0, 0});
+  auto const anchor_offset = cursorRect (anchor).top ();
+
   auto cursor = textCursor ();
   cursor.movePosition (location);
   auto block_format = cursor.blockFormat ();
@@ -225,12 +311,24 @@ void DisplayText::insertText(QString const& text, QColor bg, QColor fg
 
   // position so viewport scrolled to left
   cursor.movePosition (QTextCursor::StartOfLine);
-  if (!high_volume_ || !m_config || !m_config->decodes_from_top ())
+  if (was_following && (!high_volume_ || !m_config || !m_config->decodes_from_top ()))
     {
       setTextCursor (cursor);
       ensureCursorVisible ();
     }
   document ()->setMaximumBlockCount (document ()->maximumBlockCount ());
+  auto * vertical_scroll_bar = verticalScrollBar ();
+  if (was_following)
+    {
+      last_auto_scroll_position_ = vertical_scroll_bar->value ();
+    }
+  else
+    {
+      // hold the parked view on the same content
+      vertical_scroll_bar->setValue (vertical_scroll_bar->value ()
+                                     + cursorRect (anchor).top () - anchor_offset);
+    }
+  update_scroll_to_bottom_button ();
 }
 
 void DisplayText::extend_vertical_scrollbar (int min, int max)
@@ -252,6 +350,8 @@ void DisplayText::extend_vertical_scrollbar (int min, int max)
 
 void DisplayText::new_period ()
 {
+  // sample this before the block count and scroll bar range are altered below
+  auto const was_following = following ();
   if (m_config->decodes_from_top ()) {
     document ()->setMaximumBlockCount (4800);
     document ()->setMaximumBlockCount (5000);
@@ -275,7 +375,12 @@ void DisplayText::new_period ()
                                                extend_vertical_scrollbar (min, max );
                                              });
     }
-  verticalScrollBar ()->setSliderPosition (verticalScrollBar ()->maximum ());
+  if (was_following)
+    {
+      verticalScrollBar ()->setSliderPosition (verticalScrollBar ()->maximum ());
+      last_auto_scroll_position_ = verticalScrollBar ()->value ();
+    }
+  update_scroll_to_bottom_button ();
 }
 
 QString DisplayText::appendWorkedB4 (QString message, QString call, QString const& grid,

--- a/widgets/displaytext.h
+++ b/widgets/displaytext.h
@@ -50,8 +50,8 @@ public:
   Q_SLOT void insertText (QString const& text, QColor bg = QColor {}, QColor fg = QColor {}
                           , QString const& call1 = QString {}, QString const& call2 = QString {}, QTextCursor::MoveOperation location=QTextCursor::End);
   Q_SLOT void erase ();
-  // jump back to the newest entry and resume following it
-  Q_SLOT void scroll_to_bottom ();
+  // Jump back to the newest entry and resume following it.
+  Q_SLOT void scrollToBottom ();
   Q_SLOT void highlight_callsign (QString const& callsign, QColor const& bg, QColor const& fg, bool last_period_only);
 
 private:
@@ -63,10 +63,10 @@ private:
 
   void extend_vertical_scrollbar (int min, int max);
 
-  // true while the view is still tracking new entries, i.e. the user has
-  // not scrolled away from the position we last scrolled to
+  // Return true while the view is still tracking new entries, i.e. the user has
+  // not scrolled away from the position we last scrolled to.
   bool following () const;
-  void update_scroll_to_bottom_button ();
+  void updateScrollToBottomButton ();
 
   Configuration const * m_config;
   bool m_bPrincipalPrefix;

--- a/widgets/displaytext.h
+++ b/widgets/displaytext.h
@@ -10,6 +10,7 @@
 #include <QTimer>
 
 class QAction;
+class QToolButton;
 class Configuration;
 class LogBook;
 class DecodedText;
@@ -49,6 +50,8 @@ public:
   Q_SLOT void insertText (QString const& text, QColor bg = QColor {}, QColor fg = QColor {}
                           , QString const& call1 = QString {}, QString const& call2 = QString {}, QTextCursor::MoveOperation location=QTextCursor::End);
   Q_SLOT void erase ();
+  // jump back to the newest entry and resume following it
+  Q_SLOT void scroll_to_bottom ();
   Q_SLOT void highlight_callsign (QString const& callsign, QColor const& bg, QColor const& fg, bool last_period_only);
 
 private:
@@ -56,8 +59,14 @@ private:
   QTimer alertsTimer;
   QString leftJustifyAppendage (QString message, QString const& appendage) const;
   void mouseDoubleClickEvent (QMouseEvent *) override;
+  void resizeEvent (QResizeEvent *) override;
 
   void extend_vertical_scrollbar (int min, int max);
+
+  // true while the view is still tracking new entries, i.e. the user has
+  // not scrolled away from the position we last scrolled to
+  bool following () const;
+  void update_scroll_to_bottom_button ();
 
   Configuration const * m_config;
   bool m_bPrincipalPrefix;
@@ -73,6 +82,8 @@ private:
   bool high_volume_;
   QMetaObject::Connection vertical_scroll_connection_;
   long long modified_vertical_scrollbar_max_;
+  QToolButton * scroll_to_bottom_button_;
+  int last_auto_scroll_position_;
 };
 
 #endif // DISPLAYTEXT_H


### PR DESCRIPTION
The reason for this change was that:

- very active bands
- multithreaded and multi-pass decoding
- late arriving a priori decodes

...all add up to a constantly refreshing activity window. This constant stream of activity being written to these windows resulted in a user experience where scrolling up to check previous messages became virtually impossible, since the standard Qt widget would constantly want to snap to the bottom in order to show the latest activity that was just printed.

This PR aims to improve that usability by implementing sticky-scroll on the windows, while still strongly signalling to the user that they are not looking at live decodes. A red "Return to live activity" button appears when the user scrolls up to check past messages, making it visually clear that they're seeing stale data.

I built and tested this on arch linux running qt5 5.15.19

This is my first contribution to the project but please be critical - I'm not a strong Qt developer; just wanted to improve usability here. I won't be offended if this doesn't get merged.

Cheers - 73! Matt (W5MMW)

Here are some screenshots illustrating what the change does (the "Return to live activity" indicator isn't shown unless the user has scrolled up)

# Before
<img width="963" height="621" alt="before" src="https://github.com/user-attachments/assets/0857737b-10b5-40dd-8237-4562b3ed217c" />

# After
<img width="949" height="625" alt="after" src="https://github.com/user-attachments/assets/c0a8fa8a-3361-4e3c-a801-21162ff9529d" />