### PR TITLE
Guard against empty containers in ARRL Digi decode path (Qt6 crash)

### DIFF
--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -5876,7 +5876,7 @@ void MainWindow::ARRL_Digi_Update(DecodedText dt)
     m_latestDecodeTime=dt.timeInSeconds();
     rc.txEven = (m_latestDecodeTime % int(2*m_TRperiod)) > 0;
     rc.ready2call=false;
-    bool bCQ=dt.messageWords()[0].left(3)=="CQ ";
+    bool bCQ=!dt.messageWords().isEmpty() && dt.messageWords()[0].left(3)=="CQ ";
     if(bCQ or deGrid=="RR73" or deGrid=="73") rc.ready2call=true;
     rc.decodeTime=m_latestDecodeTime;
     m_recentCall[deCall]=rc;
@@ -6118,7 +6118,7 @@ void MainWindow::callSandP2(int n)
 void MainWindow::activeWorked(QString call, QString band)
 {
   QString bands=m_activeCall[call].bands;
-  QByteArray ba=bands.toLatin1();
+  QByteArray ba=bands.toLatin1(); if(ba.size()<7) ba=QByteArray(7,'.');
   if(band=="160m") ba[0]='a';
   if(band=="80m")  ba[1]='b';
   if(band=="40m")  ba[2]='c';
@@ -6306,7 +6306,7 @@ void MainWindow::readFromStdout()                             //readFromStdout
 //            ui->decodedTextBrowser->insertText("deCall has false syntax");
             filtered = true;
           }
-          if (word[0]!="CQ" && word[0]!="TNX" && word[0]!="73 " && word[0]!="HNY" && word[0]!="QSY" && word[0]!="PSE" &&
+          if (!word.isEmpty() && word[0]!="CQ" && word[0]!="TNX" && word[0]!="73 " && word[0]!="HNY" && word[0]!="QSY" && word[0]!="PSE" &&
               !(word[0].left(3).contains(QRegularExpression {"\\w\\d\\w"}) or
                 word[0].left(3).contains(QRegularExpression {"\\d\\w\\d"}) or
                 word[0].left(3).contains(QRegularExpression {"\\w\\w\\d"}) or


### PR DESCRIPTION
The ARRL Digital contest feature (`SpecOp::ARRL_DIGI`) indexes several
containers with the unchecked `operator[]` while processing decodes in
`MainWindow::readFromStdout()`. When a decode yields an empty result these
become out-of-bounds accesses. Under Qt6 (unlike Qt5's tolerant
`QByteRef`/`QList`) they dereference invalid memory and segfault.

Three sites, all reached only in ARRL_DIGI mode (hence rarely hit):

1. **`MainWindow::activeWorked()`** — `m_activeCall[call].bands` is empty when
   the callsign was never seeded (a default-constructed map entry), so
   `ba[0..6]=...` writes past the end of the `QByteArray`.
2. **`MainWindow::ARRL_Digi_Update()`** — `dt.messageWords()[0]` indexes an
   empty `QStringList` for a decode with no words, then `.left(3)` reads garbage.
3. **`MainWindow::readFromStdout()`** — `word[0]` indexes the result of
   `split(" ", SkipEmptyParts)`, which can be empty.

Each site gets an `isEmpty()`/`size()` guard; behavior is unchanged when the
containers are populated.

Found via gdb backtraces on a Qt6 `RelWithDebInfo` build while decoding FT8 in
ARRL_DIGI mode — the crash reproduces reliably once `jt9` produces decodes.
