### PR TITLE
fix(build): avoid jt9 SIGSEGV from gfortran stack trampolines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1177,9 +1177,21 @@ if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
     set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -isysroot ${CMAKE_OSX_SYSROOT}")
   endif (CMAKE_OSX_SYSROOT)
 
-  # Add assembler flag to disable executable stack
+  # gfortran compiles the FT8 decoder callback (an internal procedure passed as
+  # an actual argument) into a trampoline on the stack; with a non-executable
+  # stack this crashes at run time (jt9 SIGSEGV in ft8_decode) on gfortran and
+  # hardened toolchains. Prefer heap-allocated trampolines where supported
+  # (gfortran >= 14) so the stack can remain non-executable; otherwise mark the
+  # stack executable so the trampoline can run.
   if (UNIX AND NOT APPLE AND Fortran_COMPILER_NAME MATCHES "gfortran.*")
-     set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wa,--noexecstack")
+    include (CheckFortranCompilerFlag)
+    check_fortran_compiler_flag ("-ftrampoline-impl=heap" WSJT_HAVE_HEAP_TRAMPOLINES)
+    if (WSJT_HAVE_HEAP_TRAMPOLINES)
+      set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ftrampoline-impl=heap -Wa,--noexecstack")
+    else ()
+      message (STATUS "gfortran lacks -ftrampoline-impl=heap; enabling an executable stack (required by the FT8 decoder callback trampoline)")
+      set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wa,--execstack")
+    endif ()
   endif()
 
   set (CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -fbounds-check -funroll-all-loops -fno-f2c -ffpe-summary=invalid,zero,overflow,underflow ${General_FFLAGS}")


### PR DESCRIPTION
On Linux, `jt9` segfaults inside `ft8_decode` (`SIGSEGV`) with gfortran and
hardened toolchains. The FT8 decoder callback is an internal procedure passed
as an actual argument, which gfortran implements as a **trampoline placed on
the stack**. The `-Wa,--noexecstack` hardening added for certain Linux builds
marks the stack non-executable, so the trampoline can no longer run and the
process crashes as soon as a decode is produced.

This is a build-time-vs-run-time trade-off: `noexecstack` keeps strict linkers
happy but breaks the decoder at run time; an executable stack runs but trips a
linker warning on hardened distros.

The clean resolution is to stop putting the trampoline on the stack at all.
gfortran 14 added `-ftrampoline-impl=heap`, which allocates trampolines on the
heap and lets the stack stay non-executable. This PR:

- detects `-ftrampoline-impl=heap` with `check_fortran_compiler_flag`;
- **if supported (gfortran >= 14):** uses it and keeps `-Wa,--noexecstack`
  (no crash, no warning, stack stays non-executable);
- **otherwise (gfortran <= 13):** falls back to `-Wa,--execstack` so the
  trampoline can run, rather than crashing.

The fallback re-introduces the non-fatal `ld: warning: ... requires executable
stack` on older compilers — that is the correct trade-off (a warning beats a
run-time crash), and modern toolchains avoid both paths.

Verified on gfortran 13.3 (Ubuntu 24.04): without this, `jt9`'s `GNU_STACK` is
`RW` and it SIGSEGVs in `ft8_decode`; with the fallback it is `RWE` and decoding
works. gfortran >= 14 selects the heap-trampoline path.
