### PR TITLE
Add low-latency TX Inhibit for multi-op single-transmitter interlock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1798,6 +1798,10 @@ generate_version_info (wsjtx_app_version_VERSION_RESOURCES
 add_executable (wsjtx_app_version AppVersion/AppVersion.cpp ${wsjtx_app_version_VERSION_RESOURCES})
 target_link_libraries (wsjtx_app_version wsjt_qt)
 
+# Standalone KEY agent: USB-serial CTS -> UDP hold. CLI + GUI.
+# Makes TX Inhibit usable without WIMS (wims-key-agent).
+add_subdirectory (tools/inhibit-agent)
+
 generate_version_info (message_aggregator_VERSION_RESOURCES
   NAME message_aggregator
   BUNDLE ${PROJECT_BUNDLE_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ set (wsjt_qt_CXXSRCS
   Transceiver/HRDMessage.cpp
   Transceiver/HRDTransceiver.cpp
   Transceiver/DXLabSuiteCommanderTransceiver.cpp
+  TxInhibit/TxInhibitGate.cpp
   Network/NetworkMessage.cpp
   Network/MessageClient.cpp
   widgets/LettersSpinBox.cpp
@@ -1615,7 +1616,7 @@ target_link_libraries (qcp Qt5::Widgets Qt5::PrintSupport)
 add_library (wsjt_qt STATIC ${wsjt_qt_CXXSRCS} ${wsjt_qt_GENUISRCS} ${GENAXSRCS})
 # set wsjtx_udp exports to static variants
 target_compile_definitions (wsjt_qt PUBLIC UDP_STATIC_DEFINE)
-target_link_libraries (wsjt_qt Hamlib::Hamlib Boost::log qcp Qt5::Widgets Qt5::Network Qt5::Sql Qt5::WebSockets)
+target_link_libraries (wsjt_qt Hamlib::Hamlib Boost::log qcp Qt5::Widgets Qt5::Network Qt5::Sql Qt5::WebSockets Qt5::SerialPort)
 if (WIN32)
   target_link_libraries (wsjt_qt Qt5::AxContainer Qt5::AxBase)
 endif (WIN32)

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -3511,7 +3511,10 @@ void Configuration::impl::accept ()
   bLowSidelobes_ = ui_->rbLowSidelobes->isChecked();
   save_directory_.setPath (ui_->save_path_display_label->text ());
   azel_directory_.setPath (ui_->azel_path_display_label->text ());
-  enable_tx_inhibit_ = ui_->tx_inhibit_check_box->isChecked ();
+  // Match gather_rig_data(): inhibit is only live for RTS/DTR. Using the raw
+  // checkbox here left enable_tx_inhibit_ true under CAT/VOX while the gate
+  // never started — permanent "NOT protected" status (checkbox often disabled).
+  enable_tx_inhibit_ = rig_params_.enable_tx_inhibit;
   enable_VHF_features_ = ui_->enable_VHF_features_check_box->isChecked ();
   decode_at_52s_ = ui_->decode_at_52s_check_box->isChecked ();
   kHz_without_k_ = ui_->kHz_without_k_check_box->isChecked ();
@@ -5495,7 +5498,12 @@ void Configuration::impl::close_rig ()
       rig_connections_.clear ();
       rig_active_ = false;
     }
+  // Gate is gone with the transceiver; clear port *and* any held-inhibit UI
+  // state. Port alone was zeroed before without emitting, so MainWindow's
+  // m_tx_inhibited (display-only) could stick on "Inhibit" after rig close.
   tx_inhibit_port_ = 0;
+  Q_EMIT self_->tx_inhibit_port_changed (0);
+  Q_EMIT self_->tx_inhibit_changed (false, QString {}, 0, 0, 0, 0);
 }
 
 // find the audio device that matches the specified name, also

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -710,6 +710,11 @@ private:
   Configuration * const self_;	// back pointer to public interface
 
   QThread * transceiver_thread_;
+
+  // TX Inhibit: pin filter lives inside HamlibTransceiver (do_ptt). See docs/TX_INHIBIT.md.
+  bool enable_tx_inhibit_ {false};
+  quint16 tx_inhibit_port_ {0};
+
   TransceiverFactory transceiver_factory_;
   QList<QMetaObject::Connection> rig_connections_;
 
@@ -1248,6 +1253,16 @@ void Configuration::transceiver_ptt (bool on)
 {
   LOG_TRACE (on << ' ' << m_->cached_rig_state_);
   m_->transceiver_ptt (on);
+}
+
+bool Configuration::enable_tx_inhibit () const
+{
+  return m_->enable_tx_inhibit_;
+}
+
+quint16 Configuration::tx_inhibit_port () const
+{
+  return m_->tx_inhibit_port_;
 }
 
 void Configuration::transceiver_audio (bool on)
@@ -2143,6 +2158,7 @@ void Configuration::impl::initialize_models ()
   ui_->sbBandwidth->setValue (RxBandwidth_);
   ui_->tci_audio_check_box->setChecked (tci_audio_);
   ui_->PTT_method_button_group->button (rig_params_.ptt_type)->setChecked (true);
+  ui_->tx_inhibit_check_box->setChecked (enable_tx_inhibit_);
   ui_->PWR_and_SWR_check_box->setChecked (PWR_and_SWR_);
   ui_->check_SWR_check_box->setChecked (check_SWR_);
   if (!ui_->PWR_and_SWR_check_box->isChecked()) ui_->check_SWR_check_box->setEnabled (false);
@@ -2603,6 +2619,8 @@ void Configuration::impl::read_settings ()
   rig_params_.ptt_type = settings_->value ("PTTMethod", QVariant::fromValue (TransceiverFactory::PTT_method_VOX)).value<TransceiverFactory::PTTMethod> ();
   rig_params_.audio_source = settings_->value ("TXAudioSource", QVariant::fromValue (TransceiverFactory::TX_audio_source_front)).value<TransceiverFactory::TXAudioSource> ();
   rig_params_.ptt_port = settings_->value ("PTTport").toString ();
+  enable_tx_inhibit_ = settings_->value ("EnableTxInhibit", false).toBool ();
+  rig_params_.enable_tx_inhibit = enable_tx_inhibit_;
   data_mode_ = settings_->value ("DataMode", QVariant::fromValue (data_mode_none)).value<Configuration::DataMode> ();
   bLowSidelobes_ = settings_->value("LowSidelobes",true).toBool();
   prompt_to_log_ = settings_->value ("PromptToLog", false).toBool ();
@@ -2816,6 +2834,7 @@ void Configuration::impl::write_settings ()
   settings_->setValue ("CATTCIPort", rig_params_.tci_port);
   settings_->setValue ("PTTMethod", QVariant::fromValue (rig_params_.ptt_type));
   settings_->setValue ("PTTport", rig_params_.ptt_port);
+  settings_->setValue ("EnableTxInhibit", enable_tx_inhibit_);
   settings_->setValue ("SaveDir", save_directory_.absolutePath ());
   settings_->setValue ("AzElDir", azel_directory_.absolutePath ());
   if (!audio_input_device_.isNull ()) {
@@ -3017,6 +3036,8 @@ void Configuration::impl::set_rig_invariants ()
   auto enable_ptt_port = TransceiverFactory::PTT_method_CAT != ptt_method && TransceiverFactory::PTT_method_VOX != ptt_method;
   ui_->PTT_port_combo_box->setEnabled (enable_ptt_port);
   ui_->PTT_port_label->setEnabled (enable_ptt_port);
+  // TX Inhibit only applies to RTS/DTR pin keying.
+  ui_->tx_inhibit_check_box->setEnabled (enable_ptt_port && !is_tci_);
 
   if (CAT_indirect_serial_PTT)
     {
@@ -3273,6 +3294,9 @@ TransceiverFactory::ParameterPack Configuration::impl::gather_rig_data ()
   if (is_tci_ && ui_->tci_audio_check_box->isChecked ()) result.poll_interval |= tci__audio;
   result.ptt_type = static_cast<TransceiverFactory::PTTMethod> (ui_->PTT_method_button_group->checkedId ());
   result.ptt_port = ui_->PTT_port_combo_box->currentText ();
+  result.enable_tx_inhibit = ui_->tx_inhibit_check_box->isChecked ()
+    && (TransceiverFactory::PTT_method_DTR == result.ptt_type
+        || TransceiverFactory::PTT_method_RTS == result.ptt_type);
   result.audio_source = static_cast<TransceiverFactory::TXAudioSource> (ui_->TX_audio_source_button_group->checkedId ());
   result.split_mode = static_cast<TransceiverFactory::SplitMode> (ui_->split_mode_button_group->checkedId ());
   return result;
@@ -3487,6 +3511,7 @@ void Configuration::impl::accept ()
   bLowSidelobes_ = ui_->rbLowSidelobes->isChecked();
   save_directory_.setPath (ui_->save_path_display_label->text ());
   azel_directory_.setPath (ui_->azel_path_display_label->text ());
+  enable_tx_inhibit_ = ui_->tx_inhibit_check_box->isChecked ();
   enable_VHF_features_ = ui_->enable_VHF_features_check_box->isChecked ();
   decode_at_52s_ = ui_->decode_at_52s_check_box->isChecked ();
   kHz_without_k_ = ui_->kHz_without_k_check_box->isChecked ();
@@ -5050,6 +5075,12 @@ bool Configuration::impl::open_rig (bool force)
           if (is_tci_ && rig_active_ && tci_audio_) restart_tci_device_ = true;
           close_rig ();
 
+          // Stock Hamlib open (including RTS/DTR). Optional TX Inhibit is a
+          // pin filter inside HamlibTransceiver::do_ptt when enabled and PTT
+          // is RTS/DTR — no VOX rewrite, no second serial open.
+          // See docs/TX_INHIBIT.md.
+          tx_inhibit_port_ = 0;
+
           // create a new Transceiver object
           auto rig = transceiver_factory_.create (rig_data, transceiver_thread_);
           cached_rig_state_ = Transceiver::TransceiverState {};
@@ -5066,6 +5097,20 @@ bool Configuration::impl::open_rig (bool force)
           rig_connections_ << connect (rig.get (), &Transceiver::resolution, this, [=] (int resolution) {
               rig_resolution_ = resolution;
             });
+          // TX Inhibit badge / KEY-agent port (optional; only when enabled).
+          rig_connections_ << connect (rig.get (), &Transceiver::tx_inhibit_changed,
+                                       this, [this] (bool inhibited, QString const& source
+                                                     , quint32 hold_rx, quint32 release_rx
+                                                     , quint32 expiries, quint32 invalid) {
+                                         Q_EMIT self_->tx_inhibit_changed (inhibited, source
+                                                                           , hold_rx, release_rx
+                                                                           , expiries, invalid);
+                                       });
+          rig_connections_ << connect (rig.get (), &Transceiver::tx_inhibit_port_bound,
+                                       this, [this] (quint16 port) {
+                                         tx_inhibit_port_ = port;
+                                         Q_EMIT self_->tx_inhibit_port_changed (port);
+                                       });
           rig_connections_ << connect (rig.get (), &Transceiver::tciframeswritten, this, &Configuration::impl::handle_transceiver_tciframeswritten);
           rig_connections_ << connect (rig.get (), &Transceiver::tci_mod_active, this, &Configuration::impl::handle_transceiver_tci_mod_active);
           rig_connections_ << connect (rig.get (), &Transceiver::update, this, &Configuration::impl::handle_transceiver_update);
@@ -5188,7 +5233,8 @@ void Configuration::impl::transceiver_ptt (bool on)
   cached_rig_state_.online (true); // we want the rig online
   set_cached_mode ();
   cached_rig_state_.ptt (on);
-  // qDebug () << "Configuration::impl::transceiver_ptt: n:" << transceiver_command_number_ + 1 << "on:" << on;
+  // Stock path only. TX Inhibit (if any) filters inside HamlibTransceiver::do_ptt
+  // after Fake It QSY — Configuration does not own PTT or hold state.
   LOG_TRACE ("emitting set_transceiver: requested state:" << cached_rig_state_);
   Q_EMIT set_transceiver (cached_rig_state_, ++transceiver_command_number_);
 }
@@ -5449,6 +5495,7 @@ void Configuration::impl::close_rig ()
       rig_connections_.clear ();
       rig_active_ = false;
     }
+  tx_inhibit_port_ = 0;
 }
 
 // find the audio device that matches the specified name, also

--- a/Configuration.hpp
+++ b/Configuration.hpp
@@ -386,7 +386,16 @@ public:
   // Note that this must be called even if VOX PTT is selected since
   // the "Emulate Split" mode requires PTT information to coordinate
   // frequency changes.
+  //
+  // When PTT is DTR/RTS and TX Inhibit is enabled, HamlibTransceiver may
+  // install a pin filter (assert PTT ⇔ want_tx and not hold). Sequencing
+  // and CAT remain stock; Configuration does not drive RTS/DTR itself.
   Q_SLOT void transceiver_ptt (bool = true);
+
+  // Settings: Enable TX Inhibit. Default false.
+  bool enable_tx_inhibit () const;
+  // Bound UDP block listen port (0 if not active).
+  quint16 tx_inhibit_port () const;
 //  Q_SLOT void transceiver_tune (bool = true);
 
   // Set/unset Audio streaming for TCI.
@@ -473,6 +482,13 @@ public:
   // re-established with a call to transceiver_online(true) assuming
   // the fault condition has been rectified or is transient.
   Q_SIGNAL void transceiver_failure (QString const& reason) const;
+
+  // TX Inhibit block level changed (status-bar badge + InhibitStatus).
+  // source empty when clear; otherwise badge text ("TX INHIBITED — …").
+  Q_SIGNAL void tx_inhibit_changed (bool inhibited, QString const& source
+                                    , quint32 hold_rx, quint32 release_rx
+                                    , quint32 expiries, quint32 invalid) const;
+  Q_SIGNAL void tx_inhibit_port_changed (quint16 port) const;
 
   // signal announces audio devices are being enumerated
   //

--- a/Configuration.ui
+++ b/Configuration.ui
@@ -1451,6 +1451,16 @@ other hardware interface for PTT.</string>
               </property>
              </widget>
             </item>
+            <item row="1" column="0" colspan="2">
+             <widget class="QCheckBox" name="tx_inhibit_check_box">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;b&gt;TX Inhibit&lt;/b&gt; (RTS/DTR PTT only).&lt;/p&gt;&lt;p&gt;This &lt;b&gt;WSJT-X station&lt;/b&gt; is the app, PC, network, radio, and antenna (may be a remote go-box). When enabled, listen for UDP from a KEY agent (default port 22372). The KEY agent &lt;b&gt;tells WSJT-X stations not to transmit&lt;/b&gt; while a priority radio is keyed. Physical outcome: &lt;code&gt;assert PTT ⇔ want_tx and not hold&lt;/code&gt;. Sequencing continues; only whether this station may assert PTT is filtered.&lt;/p&gt;&lt;p&gt;Default is off (stock PTT). Co-band multi-op stations that share a band with a priority radio should enable this and run a KEY agent.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Enable TX &amp;Inhibit</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
          </layout>

--- a/Network/MessageClient.cpp
+++ b/Network/MessageClient.cpp
@@ -617,6 +617,23 @@ void MessageClient::decode (bool is_new, QTime time, qint32 snr, float delta_tim
     }
 }
 
+void MessageClient::inhibit_status (quint16 inhibit_port, bool inhibited
+                                    , QString const& source_station
+                                    , quint32 hold_rx, quint32 release_rx
+                                    , quint32 expiries, quint32 invalid)
+{
+  if (m_->server_port_ && !m_->server_.isNull ())
+    {
+      QByteArray message;
+      NetworkMessage::Builder out {&message, NetworkMessage::InhibitStatus, m_->id_, m_->schema_};
+      out << inhibit_port << inhibited << source_station.toUtf8 ()
+          << hold_rx << release_rx << expiries << invalid;
+      TRACE_UDP ("inhibit_port:" << inhibit_port << "inhibited:" << inhibited
+                 << "source:" << source_station);
+      m_->send_message (out, message);
+    }
+}
+
 void MessageClient::WSPR_decode (bool is_new, QTime time, qint32 snr, float delta_time, Frequency frequency
                                  , qint32 drift, QString const& callsign, QString const& grid, qint32 power
                                  , bool off_air)

--- a/Network/MessageClient.hpp
+++ b/Network/MessageClient.hpp
@@ -85,6 +85,12 @@ public:
   // of record marker
   Q_SLOT void logged_ADIF (QByteArray const& ADIF_record);
 
+  // TX Inhibit status (NetworkMessage::InhibitStatus) — WSJT-X station telemetry for agents/tools.
+  Q_SLOT void inhibit_status (quint16 inhibit_port, bool inhibited
+                              , QString const& source_station
+                              , quint32 hold_rx, quint32 release_rx
+                              , quint32 expiries, quint32 invalid);
+
   // this signal is emitted if the server has requested a decode
   // window clear action
   Q_SIGNAL void clear_decodes (quint8 window);

--- a/Network/NetworkMessage.hpp
+++ b/Network/NetworkMessage.hpp
@@ -529,6 +529,29 @@
  *      ffffffff will remove the sort-order value from the internal table.
  *      Callsigns without a sort order will be valued at zero for sorting purposes
  *      in the hound display.
+ *
+ *
+ * InhibitStatus  Out      17
+ *                         Id (unique key)        utf8
+ *                         Inhibit port           quint16
+ *                         Inhibited              bool
+ *                         Source station         utf8
+ *                         Hold rx                quint32
+ *                         Release rx             quint32
+ *                         Expiries               quint32
+ *                         Invalid                quint32
+ *
+ *      Optional telemetry when TX Inhibit is enabled (Settings → Radio)
+ *      and the WSJT-X station block level or badge text changes. KEY-agent UDP
+ *      protocol is separate; see docs/TX_INHIBIT.md.
+ *
+ *      Inhibit port: UDP listen port for KEY-agent blocks (usually 22372;
+ *      may be ephemeral). Inhibited: block active. Source station: badge
+ *      text (may be empty). Four quint32 counters: hold packets received,
+ *      explicit release hold, hold timeout expiries (incl. after a deadman),
+ *      invalid datagrams (field names hold_rx etc. are historical wire labels).
+ *
+ *      Unknown types are ignored; schema number unchanged.
  */
 
 #include <QDataStream>
@@ -561,6 +584,7 @@ namespace NetworkMessage
       SwitchConfiguration,
       Configure,
       AnnotationInfo,
+      InhibitStatus,            // Out 17 — see protocol comment above
       maximum_message_type_     // ONLY add new message types
                                 // immediately before here
     };

--- a/Transceiver/DXLabSuiteCommanderTransceiver.cpp
+++ b/Transceiver/DXLabSuiteCommanderTransceiver.cpp
@@ -54,6 +54,17 @@ DXLabSuiteCommanderTransceiver::DXLabSuiteCommanderTransceiver (logger_type * lo
   , server_ {address}
   , commander_ {nullptr}
 {
+  // Forward optional TX Inhibit telemetry from the wrapped PTT-only rig.
+  // Without this the gate still holds PTT off correctly, but the operator gets
+  // no badge, no tooltip and no InhibitStatus -- PTT simply stops working with
+  // no visible reason. See docs/REVIEW-rc2.md C3.
+  if (wrapped_)
+    {
+      connect (wrapped_.get (), &Transceiver::tx_inhibit_changed,
+               this, &Transceiver::tx_inhibit_changed);
+      connect (wrapped_.get (), &Transceiver::tx_inhibit_port_bound,
+               this, &Transceiver::tx_inhibit_port_bound);
+    }
 }
 
 int DXLabSuiteCommanderTransceiver::do_start ()

--- a/Transceiver/EmulateSplitTransceiver.cpp
+++ b/Transceiver/EmulateSplitTransceiver.cpp
@@ -21,6 +21,8 @@ EmulateSplitTransceiver::EmulateSplitTransceiver (logger_type * logger,
   connect (wrapped_.get (), &Transceiver::tci_mod_active, this, &Transceiver::tci_mod_active);
   connect (wrapped_.get (), &Transceiver::finished, this, &Transceiver::finished);
   connect (wrapped_.get (), &Transceiver::failure, this, &Transceiver::failure);
+  connect (wrapped_.get (), &Transceiver::tx_inhibit_changed, this, &Transceiver::tx_inhibit_changed);
+  connect (wrapped_.get (), &Transceiver::tx_inhibit_port_bound, this, &Transceiver::tx_inhibit_port_bound);
 }
 
 void EmulateSplitTransceiver::set (TransceiverState const& s, unsigned sequence_number) noexcept

--- a/Transceiver/HRDTransceiver.cpp
+++ b/Transceiver/HRDTransceiver.cpp
@@ -69,6 +69,17 @@ HRDTransceiver::HRDTransceiver (logger_type * logger
   , alt_ptt_button_ {-1}
   , reversed_ {false}
 {
+  // Forward optional TX Inhibit telemetry from the wrapped PTT-only rig.
+  // Without this the gate still holds PTT off correctly, but the operator gets
+  // no badge, no tooltip and no InhibitStatus -- PTT simply stops working with
+  // no visible reason. See docs/REVIEW-rc2.md C3.
+  if (wrapped_)
+    {
+      connect (wrapped_.get (), &Transceiver::tx_inhibit_changed,
+               this, &Transceiver::tx_inhibit_changed);
+      connect (wrapped_.get (), &Transceiver::tx_inhibit_port_bound,
+               this, &Transceiver::tx_inhibit_port_bound);
+    }
 }
 
 int HRDTransceiver::do_start ()

--- a/Transceiver/HamlibTransceiver.cpp
+++ b/Transceiver/HamlibTransceiver.cpp
@@ -882,6 +882,16 @@ int HamlibTransceiver::do_start ()
 
   do_poll ();
 
+  // USB-serial open asserts RTS/DTR. Drop PTT before the gate starts so a
+  // port-open glitch cannot leave the radio keyed.
+  try
+    {
+      apply_physical_ptt (false);
+    }
+  catch (...)
+    {
+    }
+
   // After rig_open: optional TX Inhibit (RTS/DTR only). Same thread as CAT.
   if (use_tx_inhibit_)
     {

--- a/Transceiver/HamlibTransceiver.cpp
+++ b/Transceiver/HamlibTransceiver.cpp
@@ -1,4 +1,5 @@
 #include "HamlibTransceiver.hpp"
+#include "TxInhibit/TxInhibitGate.hpp"
 
 #include <cstring>
 #include <cmath>
@@ -411,8 +412,11 @@ rmode_t HamlibTransceiver::impl::map_mode (MODE mode) const
 
 HamlibTransceiver::HamlibTransceiver (logger_type * logger,
                                       TransceiverFactory::PTTMethod ptt_type, QString const& ptt_port,
-                                      QObject * parent)
+                                      bool enable_tx_inhibit, QObject * parent)
   : PollingTransceiver {logger, 0, parent}
+  , use_tx_inhibit_ {enable_tx_inhibit
+                     && (TransceiverFactory::PTT_method_DTR == ptt_type
+                         || TransceiverFactory::PTT_method_RTS == ptt_type)}
   , m_ {logger}
 {
   if (!m_->rig_)
@@ -432,6 +436,8 @@ HamlibTransceiver::HamlibTransceiver (logger_type * logger,
 
     case TransceiverFactory::PTT_method_DTR:
     case TransceiverFactory::PTT_method_RTS:
+      // Stock Hamlib RTS/DTR (shared CAT port uses same fd). TX Inhibit
+      // filters do_ptt → apply_physical_ptt; it does not open the port.
       if (!ptt_port.isEmpty ())
         {
 #if defined (WIN32)
@@ -461,6 +467,9 @@ HamlibTransceiver::HamlibTransceiver (logger_type * logger,
                                       TransceiverFactory::ParameterPack const& params,
                                       QObject * parent)
   : PollingTransceiver {logger, params.poll_interval, parent}
+  , use_tx_inhibit_ {params.enable_tx_inhibit
+                     && (TransceiverFactory::PTT_method_DTR == params.ptt_type
+                         || TransceiverFactory::PTT_method_RTS == params.ptt_type)}
   , m_ {logger, model_number, params}
 {
   if (!m_->rig_)
@@ -873,12 +882,94 @@ int HamlibTransceiver::do_start ()
 
   do_poll ();
 
+  // After rig_open: optional TX Inhibit (RTS/DTR only). Same thread as CAT.
+  if (use_tx_inhibit_)
+    {
+      start_tx_inhibit_gate ();
+    }
+
   CAT_TRACE ("finished start " << state () << " reversed=" << m_->reversed_ << " resolution=" << resolution);
   return resolution;
 }
 
+void HamlibTransceiver::start_tx_inhibit_gate ()
+{
+  if (inhibit_gate_)
+    {
+      return;
+    }
+  // Child of this object → transceiver thread; DirectConnection to pin apply.
+  inhibit_gate_ = new TxInhibitGate {this};
+  connect (inhibit_gate_, &TxInhibitGate::physicalPtt,
+           this, &HamlibTransceiver::apply_physical_ptt, Qt::DirectConnection);
+  connect (inhibit_gate_, &TxInhibitGate::inhibitChanged,
+           this, &Transceiver::tx_inhibit_changed);
+  connect (inhibit_gate_, &TxInhibitGate::portBound,
+           this, &Transceiver::tx_inhibit_port_bound);
+  // UDP bind problems are non-fatal: keep stock intent→pin path, log only.
+  connect (inhibit_gate_, &TxInhibitGate::lineError,
+           this, [this] (QString const& msg) {
+             CAT_TRACE (msg);
+           });
+  inhibit_gate_->start_listening ();
+  CAT_TRACE ("TX Inhibit gate listening (pin filter on do_ptt)");
+}
+
+void HamlibTransceiver::stop_tx_inhibit_gate ()
+{
+  if (!inhibit_gate_)
+    {
+      return;
+    }
+  // Drop pin connection first so destructor / second shutdown cannot call
+  // rig_set_ptt after rig_close (Hamlib CHECK_RIG_ARG fails if !comm_state).
+  disconnect (inhibit_gate_, &TxInhibitGate::physicalPtt,
+              this, &HamlibTransceiver::apply_physical_ptt);
+  // Safe pin-low while the port is still open.
+  try
+    {
+      apply_physical_ptt (false);
+    }
+  catch (...)
+    {
+      // Teardown must not throw.
+    }
+  // No further pin emits from the gate.
+  inhibit_gate_->shutdown (false);
+  inhibit_gate_->deleteLater ();
+  inhibit_gate_ = nullptr;
+}
+
+void HamlibTransceiver::apply_physical_ptt (bool radiate)
+{
+  // Lowest-level PTT write through Hamlib (RTS/DTR or CAT PTT type).
+  // Hamlib rejects set_ptt when comm_state is false (not open / already closed).
+  if (!m_->rig_ || !m_->rig_->caps
+      || !m_->rig_->state.comm_state
+      || RIG_PTT_NONE == m_->rig_->state.pttport.type.ptt)
+    {
+      CAT_TRACE ("apply_physical_ptt skipped (no open rig/ptt) radiate=" << radiate);
+      return;
+    }
+  if (radiate)
+    {
+      CAT_TRACE ("apply_physical_ptt ON");
+      auto ptt_type = rig_get_caps_int (m_->model_, RIG_CAPS_PTT_TYPE);
+      m_->error_check (rig_set_ptt (m_->rig_.data (), RIG_VFO_CURR
+                                    , RIG_PTT_RIG_MICDATA == ptt_type && m_->back_ptt_port_
+                                    ? RIG_PTT_ON_DATA : RIG_PTT_ON), tr ("setting PTT on"));
+    }
+  else
+    {
+      CAT_TRACE ("apply_physical_ptt OFF");
+      m_->error_check (rig_set_ptt (m_->rig_.data (), RIG_VFO_CURR, RIG_PTT_OFF), tr ("setting PTT off"));
+    }
+}
+
 void HamlibTransceiver::do_stop ()
 {
+  // Gate down (and pin low) before closing the serial port.
+  stop_tx_inhibit_gate ();
   if (m_->is_dummy_ && !m_->ptt_only_)
     {
       rig_get_freq (m_->rig_.data (), RIG_VFO_CURR, &impl::dummy_frequency_);
@@ -1214,7 +1305,11 @@ void HamlibTransceiver::do_poll ()
         }
     }
 
-  if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt && rig_get_function_ptr (m_->model_, RIG_FUNCTION_GET_PTT))
+  // Under TX Inhibit, software PTT follows WSJT-X intent (do_ptt), not the
+  // physical pin (which is held low during a KEY-agent hold). Skip GET_PTT.
+  if (!inhibit_gate_
+      && RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt
+      && rig_get_function_ptr (m_->model_, RIG_FUNCTION_GET_PTT))
   {
     ptt_t p;
     auto rc = rig_get_ptt (m_->rig_.data (), RIG_VFO_CURR, &p);
@@ -1281,29 +1376,25 @@ void HamlibTransceiver::do_poll ()
 
 void HamlibTransceiver::do_ptt (bool on)
 {
-    CAT_TRACE ("PTT: " << on << " " << state () << " reversed=" << m_->reversed_);
-  if (on)
+  CAT_TRACE ("PTT: " << on << " " << state () << " reversed=" << m_->reversed_);
+  // Upstream only tracks ptt_on_ for rigs that actually have a PTT port, and
+  // do_poll() gates its PWR/SWR reads on it. Hoisting this above the guard
+  // turned those reads on for RIG_PTT_NONE rigs -- a change to the stock path
+  // that has nothing to do with TX Inhibit, and would not belong in a
+  // merge-back diff. See docs/REVIEW-rc2.md C5.
+  if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt)
     {
-       if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt)
-        {
-          ptt_on_ = true;
-          CAT_TRACE ("rig_set_ptt PTT=true");
-          auto ptt_type = rig_get_caps_int (m_->model_, RIG_CAPS_PTT_TYPE);
-          m_->error_check (rig_set_ptt (m_->rig_.data (), RIG_VFO_CURR
-                                        , RIG_PTT_RIG_MICDATA == ptt_type && m_->back_ptt_port_
-                                        ? RIG_PTT_ON_DATA : RIG_PTT_ON), tr ("setting PTT on"));
-        }
+      ptt_on_ = on;
     }
-  else
+  if (inhibit_gate_)
     {
-      if (RIG_PTT_NONE != m_->rig_->state.pttport.type.ptt)
-        {
-          ptt_on_ = false;
-          CAT_TRACE ("rig_set_ptt PTT=false");
-          m_->error_check (rig_set_ptt (m_->rig_.data (), RIG_VFO_CURR, RIG_PTT_OFF), tr ("setting PTT off"));
-        }
+      // Stock sequencing already did Fake It QSY. Intent only; gate mixes
+      // private UDP hold and emits physicalPtt → apply_physical_ptt.
+      inhibit_gate_->set_intent (on);
+      update_PTT (on); // software PTT state follows intent (not pin)
+      return;
     }
-
+  apply_physical_ptt (on);
   update_PTT (on);
 }
 

--- a/Transceiver/HamlibTransceiver.cpp
+++ b/Transceiver/HamlibTransceiver.cpp
@@ -911,6 +911,13 @@ void HamlibTransceiver::start_tx_inhibit_gate ()
            this, [this] (QString const& msg) {
              CAT_TRACE (msg);
            });
+  // Pin apply failure: same visibility as stock rig_set_ptt throw path.
+  // Exception is already contained in the gate (no qFatal from timer slots).
+  connect (inhibit_gate_, &TxInhibitGate::pttApplyFailed,
+           this, [this] (QString const& msg) {
+             CAT_TRACE (msg);
+             Q_EMIT failure (msg);
+           });
   inhibit_gate_->start_listening ();
   CAT_TRACE ("TX Inhibit gate listening (pin filter on do_ptt)");
 }

--- a/Transceiver/HamlibTransceiver.hpp
+++ b/Transceiver/HamlibTransceiver.hpp
@@ -7,6 +7,8 @@
 #include "PollingTransceiver.hpp"
 #include "pimpl_h.hpp"
 
+class TxInhibitGate;
+
 // hamlib transceiver and PTT mostly delegated directly to hamlib Rig class
 class HamlibTransceiver final
   : public PollingTransceiver
@@ -19,8 +21,9 @@ public:
 
   explicit HamlibTransceiver (logger_type *, unsigned model_number, TransceiverFactory::ParameterPack const&,
                               QObject * parent = nullptr);
+  // PTT-only helper used under DXLab/HRD/OmniRig wrappers (no CAT model).
   explicit HamlibTransceiver (logger_type *, TransceiverFactory::PTTMethod ptt_type, QString const& ptt_port,
-                              QObject * parent = nullptr);
+                              bool enable_tx_inhibit = false, QObject * parent = nullptr);
   ~HamlibTransceiver ();
 
 private:
@@ -35,10 +38,18 @@ private:
 
   void do_poll () override;
 
+  // Actual Hamlib pin/CAT PTT (used by stock path and by the inhibit gate).
+  void apply_physical_ptt (bool radiate);
+  void start_tx_inhibit_gate ();
+  void stop_tx_inhibit_gate ();
+
   bool ptt_on_ = false;
   bool do_pwr_;
   bool do_pwr2_;
   bool do_swr_;
+  // True when Settings "Enable TX Inhibit" is on and PTT method is RTS/DTR.
+  bool use_tx_inhibit_ = false;
+  TxInhibitGate * inhibit_gate_ = nullptr;
 
   class impl;
   pimpl<impl> m_;

--- a/Transceiver/OmniRigTransceiver.cpp
+++ b/Transceiver/OmniRigTransceiver.cpp
@@ -111,6 +111,17 @@ OmniRigTransceiver::OmniRigTransceiver (logger_type * the_logger,
   , reversed_ {false}
 {
   CoInitializeEx (nullptr, 0 /*COINIT_APARTMENTTHREADED*/); // required because Qt only does this for GUI thread
+  // Forward optional TX Inhibit telemetry from the wrapped PTT-only rig.
+  // Without this the gate still holds PTT off correctly, but the operator gets
+  // no badge, no tooltip and no InhibitStatus -- PTT simply stops working with
+  // no visible reason. See docs/REVIEW-rc2.md C3.
+  if (wrapped_)
+    {
+      connect (wrapped_.get (), &Transceiver::tx_inhibit_changed,
+               this, &Transceiver::tx_inhibit_changed);
+      connect (wrapped_.get (), &Transceiver::tx_inhibit_port_bound,
+               this, &Transceiver::tx_inhibit_port_bound);
+    }
   CAT_TRACE ("constructed");
 }
 

--- a/Transceiver/TCITransceiver.cpp
+++ b/Transceiver/TCITransceiver.cpp
@@ -206,6 +206,17 @@ TCITransceiver::TCITransceiver (logger_type * logger, std::unique_ptr<Transceive
   , m_toneFrequency0 {1500.0}
   , wav_file_ {QDir(QStandardPaths::writableLocation (QStandardPaths::DataLocation)).absoluteFilePath ("tx.wav").toStdString()}
 {
+  // Forward optional TX Inhibit telemetry from the wrapped PTT-only rig.
+  // Without this the gate still holds PTT off correctly, but the operator gets
+  // no badge, no tooltip and no InhibitStatus -- PTT simply stops working with
+  // no visible reason. See docs/REVIEW-rc2.md C3.
+  if (wrapped_)
+    {
+      connect (wrapped_.get (), &Transceiver::tx_inhibit_changed,
+               this, &Transceiver::tx_inhibit_changed);
+      connect (wrapped_.get (), &Transceiver::tx_inhibit_port_bound,
+               this, &Transceiver::tx_inhibit_port_bound);
+    }
   m_samplesPerFFT = 6912 / 2;
   tci_Ready = false;
   trxA = 0;

--- a/Transceiver/Transceiver.hpp
+++ b/Transceiver/Transceiver.hpp
@@ -250,6 +250,13 @@ public:
   // something went wrong - not recoverable, start new instance
   Q_SIGNAL void failure (QString const& reason) const;
 
+  // Optional TX Inhibit (RTS/DTR + Settings enabled). Default: never emitted.
+  // Decorators (e.g. EmulateSplit) must forward these from the wrapped rig.
+  Q_SIGNAL void tx_inhibit_changed (bool inhibited, QString const& source
+                                    , quint32 hold_rx, quint32 release_rx
+                                    , quint32 expiries, quint32 invalid) const;
+  Q_SIGNAL void tx_inhibit_port_bound (quint16 port) const;
+
   // Ready to be destroyed.
   Q_SIGNAL void finished () const;
 

--- a/Transceiver/TransceiverFactory.cpp
+++ b/Transceiver/TransceiverFactory.cpp
@@ -122,7 +122,7 @@ std::unique_ptr<Transceiver> TransceiverFactory::create (ParameterPack const& pa
         if (PTT_method_CAT != params.ptt_type)
           {
             // we start with a dummy HamlibTransceiver object instance that can support direct PTT
-            basic_transceiver.reset (new HamlibTransceiver {&logger_, params.ptt_type, params.ptt_port});
+            basic_transceiver.reset (new HamlibTransceiver {&logger_, params.ptt_type, params.ptt_port, params.enable_tx_inhibit});
             if (target_thread)
               {
                 basic_transceiver.get ()->moveToThread (target_thread);
@@ -144,7 +144,7 @@ std::unique_ptr<Transceiver> TransceiverFactory::create (ParameterPack const& pa
         if (PTT_method_CAT != params.ptt_type)
           {
             // we start with a dummy HamlibTransceiver object instance that can support direct PTT
-            basic_transceiver.reset (new HamlibTransceiver {&logger_, params.ptt_type, params.ptt_port});
+            basic_transceiver.reset (new HamlibTransceiver {&logger_, params.ptt_type, params.ptt_port, params.enable_tx_inhibit});
             if (target_thread)
               {
                 basic_transceiver.get ()->moveToThread (target_thread);
@@ -167,7 +167,7 @@ std::unique_ptr<Transceiver> TransceiverFactory::create (ParameterPack const& pa
         if (PTT_method_CAT != params.ptt_type && "CAT" != params.ptt_port)
           {
             // we start with a dummy HamlibTransceiver object instance that can support direct PTT
-            basic_transceiver.reset (new HamlibTransceiver {&logger_, params.ptt_type, params.ptt_port});
+            basic_transceiver.reset (new HamlibTransceiver {&logger_, params.ptt_type, params.ptt_port, params.enable_tx_inhibit});
             if (target_thread)
               {
                 basic_transceiver.get ()->moveToThread (target_thread);
@@ -189,7 +189,7 @@ std::unique_ptr<Transceiver> TransceiverFactory::create (ParameterPack const& pa
         if (PTT_method_CAT != params.ptt_type && "CAT" != params.ptt_port)
           {
             // we start with a dummy HamlibTransceiver object instance that can support direct PTT
-            basic_transceiver.reset (new HamlibTransceiver {&logger_, params.ptt_type, params.ptt_port});
+            basic_transceiver.reset (new HamlibTransceiver {&logger_, params.ptt_type, params.ptt_port, params.enable_tx_inhibit});
             if (target_thread)
               {
                 basic_transceiver.get ()->moveToThread (target_thread);

--- a/Transceiver/TransceiverFactory.hpp
+++ b/Transceiver/TransceiverFactory.hpp
@@ -127,6 +127,9 @@ public:
                                 // value "CAT"
     int poll_interval;          // in seconds for interfaces that
                                 // require polling for state changes
+    // When true and ptt_type is RTS/DTR, HamlibTransceiver installs the
+    // TX Inhibit pin filter (UDP KEY-agent holds). Default off (stock path).
+    bool enable_tx_inhibit {false};
 
     bool operator == (ParameterPack const& rhs) const
     {
@@ -148,6 +151,7 @@ public:
         && rhs.split_mode == split_mode
         && rhs.ptt_port == ptt_port
         && rhs.poll_interval == poll_interval
+        && rhs.enable_tx_inhibit == enable_tx_inhibit
         ;
     }
   };

--- a/TxInhibit/TxInhibitGate.cpp
+++ b/TxInhibit/TxInhibitGate.cpp
@@ -1,0 +1,229 @@
+#include "TxInhibitGate.hpp"
+
+#include <exception>
+
+#include <QHostAddress>
+#include <QTimer>
+#include <QUdpSocket>
+
+TxInhibitGate::TxInhibitGate (QObject * parent)
+  : QObject {parent}
+{
+  uptime_.start ();
+}
+
+TxInhibitGate::~TxInhibitGate ()
+{
+  // Never emit physicalPtt from the destructor — Hamlib may already be closed.
+  shutdown (false);
+}
+
+qint64 TxInhibitGate::now_ms () const
+{
+  // MONOTONIC, deliberately. Hold expiry compares against an absolute value in
+  // this same time base, so a wall clock would let a clock *step* corrupt it:
+  //
+  //   step backwards  -> the hold outlives its timeout by the step size. PTT
+  //                      stays off with no packet to explain it.
+  //   step forwards   -> the hold ends early. PTT can assert while the priority
+  //                      station is still keyed -- the exact failure this
+  //                      feature exists to prevent.
+  //
+  // Not hypothetical for this audience: WSJT-X operators run Meinberg NTP,
+  // Dimension4, BktTimeSync and similar, all of which step the system clock,
+  // often repeatedly. QElapsedTimer is unaffected by clock changes.
+  // See docs/REVIEW-rc2.md C1.
+  return uptime_.isValid () ? uptime_.elapsed () : 0;
+}
+
+void TxInhibitGate::start_listening ()
+{
+  stopped_ = false;
+  // On bind failure ensure_udp emits lineError once; gate still applies intent
+  // as a pin filter but never receives holds. Non-fatal for CAT/PTT.
+  (void) ensure_udp ();
+}
+
+bool TxInhibitGate::ensure_udp ()
+{
+  if (udp_)
+    {
+      return true;
+    }
+  if (stopped_)
+    {
+      return false;
+    }
+  udp_ = new QUdpSocket (this);
+  // Prefer well-known port 22372 so KEY agents can use a fixed default.
+  // ShareAddress|ReuseAddressHint lets multiple local WSJT-X stations share 22372;
+  // which process receives a given datagram is OS-dependent — one WSJT-X station per
+  // host (or exclusive bind) is preferred for multi-op.
+  QHostAddress const any4 {QHostAddress::AnyIPv4};
+  if (!udp_->bind (any4, TxInhibit::default_gate_port,
+                   QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint))
+    {
+      if (!udp_->bind (any4, quint16 (0)))
+        {
+          QString const err = udp_->errorString ();
+          udp_->deleteLater ();
+          udp_ = nullptr;
+          Q_EMIT lineError (QStringLiteral ("TX Inhibit: UDP bind failed: %1").arg (err));
+          return false;
+        }
+    }
+  bound_port_ = udp_->localPort ();
+  QObject::connect (udp_, &QUdpSocket::readyRead, this, &TxInhibitGate::on_udp_ready);
+  Q_EMIT portBound (bound_port_);
+
+  if (!timer_)
+    {
+      timer_ = new QTimer (this);
+      // hold_timeout_ms poll; UDP hold packets are event-driven.
+      timer_->setInterval (20);
+      QObject::connect (timer_, &QTimer::timeout, this, &TxInhibitGate::tick);
+      timer_->start ();
+    }
+  return true;
+}
+
+void TxInhibitGate::set_intent (bool on)
+{
+  if (stopped_)
+    {
+      return;
+    }
+  intent_ = on;
+  apply_line ();
+}
+
+void TxInhibitGate::shutdown (bool emit_pin)
+{
+  stopped_ = true;
+  intent_ = false;
+
+  if (emit_pin && last_radiate_)
+    {
+      // Request pin low once while Hamlib is still open (caller responsibility).
+      last_radiate_ = false;
+      emit_physical_ptt (false);   // teardown must not throw
+    }
+  else
+    {
+      last_radiate_ = false;
+    }
+
+  if (timer_)
+    {
+      timer_->stop ();
+      timer_->deleteLater ();
+      timer_ = nullptr;
+    }
+  if (udp_)
+    {
+      udp_->disconnect (this);
+      udp_->close ();
+      udp_->deleteLater ();
+      udp_ = nullptr;
+      bound_port_ = 0;
+    }
+}
+
+void TxInhibitGate::on_udp_ready ()
+{
+  if (!udp_ || stopped_)
+    {
+      return;
+    }
+  while (udp_->hasPendingDatagrams ())
+    {
+      QByteArray data;
+      data.resize (static_cast<int> (udp_->pendingDatagramSize ()));
+      udp_->readDatagram (data.data (), data.size ());
+      (void) logic_.on_datagram (data, now_ms ());
+    }
+  apply_line ();
+  emit_state_if_changed ();
+}
+
+void TxInhibitGate::tick ()
+{
+  if (stopped_)
+    {
+      return;
+    }
+  (void) logic_.inhibited (now_ms ());
+  apply_line ();
+  emit_state_if_changed ();
+}
+
+void TxInhibitGate::apply_line ()
+{
+  if (stopped_)
+    {
+      return;
+    }
+  // Sole policy: assert PTT ⇔ want_tx and not hold.
+  bool const radiate = intent_ && !logic_.line_inhibited (now_ms ());
+  if (radiate == last_radiate_)
+    {
+      return;
+    }
+  last_radiate_ = radiate;
+  emit_physical_ptt (radiate);
+}
+
+// physicalPtt is a DirectConnection into HamlibTransceiver::apply_physical_ptt,
+// which calls rig_set_ptt and *throws* on any Hamlib error. This is reached from
+// tick() (a QTimer slot) and on_udp_ready() (a readyRead slot), so an escaping
+// exception would unwind through QMetaObject::activate into the transceiver
+// thread's event loop; ExceptionCatchingApplication::notify catches it and calls
+// qFatal, killing the application.
+//
+// The stock path does not have this exposure: do_ptt is called from
+// TransceiverBase::set, which already wraps everything in try/catch. Only the
+// gate-driven path is unguarded, so the catch belongs here rather than inside
+// apply_physical_ptt -- putting it there would also swallow errors on the stock
+// path, where they are supposed to propagate and fail the rig.
+//
+// Realistic trigger: serial adapter unplugged or radio powered off while a hold
+// is active and want_tx is true. The hold expires, the gate tries to assert PTT,
+// rig_set_ptt fails, and the application dies.
+//
+// last_radiate_ is deliberately NOT rolled back on failure. The pin state is
+// unknown after a failed set, and rolling back would make the 50 Hz tick retry
+// forever, turning one dead cable into an error storm. The rig's own polling
+// will notice and fail the transceiver properly.
+void TxInhibitGate::emit_physical_ptt (bool radiate)
+{
+  try
+    {
+      Q_EMIT physicalPtt (radiate);
+    }
+  catch (std::exception const& e)
+    {
+      Q_EMIT lineError (QStringLiteral ("TX Inhibit: setting PTT %1 failed: %2")
+                        .arg (radiate ? QStringLiteral ("on") : QStringLiteral ("off"))
+                        .arg (QString::fromUtf8 (e.what ())));
+    }
+  catch (...)
+    {
+      Q_EMIT lineError (QStringLiteral ("TX Inhibit: setting PTT %1 failed (unknown error)")
+                        .arg (radiate ? QStringLiteral ("on") : QStringLiteral ("off")));
+    }
+}
+
+void TxInhibitGate::emit_state_if_changed ()
+{
+  qint64 t = now_ms ();
+  bool inh = logic_.line_inhibited (t);
+  auto badge = logic_.badge_text (t);
+  if (inh != last_emitted_inhibited_ || badge != last_badge_)
+    {
+      last_emitted_inhibited_ = inh;
+      last_badge_ = badge;
+      Q_EMIT inhibitChanged (inh, badge
+                             , logic_.hold_rx (), logic_.release_rx ()
+                             , logic_.expiries (), logic_.invalid ());
+    }
+}

--- a/TxInhibit/TxInhibitGate.cpp
+++ b/TxInhibit/TxInhibitGate.cpp
@@ -202,14 +202,16 @@ void TxInhibitGate::emit_physical_ptt (bool radiate)
     }
   catch (std::exception const& e)
     {
-      Q_EMIT lineError (QStringLiteral ("TX Inhibit: setting PTT %1 failed: %2")
-                        .arg (radiate ? QStringLiteral ("on") : QStringLiteral ("off"))
-                        .arg (QString::fromUtf8 (e.what ())));
+      // Contain the exception (timer/socket slots must not qFatal) but do not
+      // hide the failure: pttApplyFailed is wired to Transceiver::failure.
+      Q_EMIT pttApplyFailed (QStringLiteral ("TX Inhibit: setting PTT %1 failed: %2")
+                             .arg (radiate ? QStringLiteral ("on") : QStringLiteral ("off"))
+                             .arg (QString::fromUtf8 (e.what ())));
     }
   catch (...)
     {
-      Q_EMIT lineError (QStringLiteral ("TX Inhibit: setting PTT %1 failed (unknown error)")
-                        .arg (radiate ? QStringLiteral ("on") : QStringLiteral ("off")));
+      Q_EMIT pttApplyFailed (QStringLiteral ("TX Inhibit: setting PTT %1 failed (unknown error)")
+                             .arg (radiate ? QStringLiteral ("on") : QStringLiteral ("off")));
     }
 }
 

--- a/TxInhibit/TxInhibitGate.hpp
+++ b/TxInhibit/TxInhibitGate.hpp
@@ -1,0 +1,100 @@
+#ifndef TX_INHIBIT_GATE_HPP__
+#define TX_INHIBIT_GATE_HPP__
+
+// ---------------------------------------------------------------------------
+// TxInhibit module — UDP listen + want_tx mix for RTS/DTR PTT
+//
+//   assert PTT  ⇔  want_tx  and  not hold
+//
+// • want_tx arrives from HamlibTransceiver::do_ptt() via set_intent().
+// • Hold is private (UDP keepalives + hold_timeout_ms safety timeout).
+//   CW anti-chatter hang lives only in the KEY agent; normal end is
+//   release hold (ttl_ms: 0). See docs/TX_INHIBIT.md §3.
+// • No serial I/O here. Hamlib owns CAT and RTS/DTR; this only decides
+//   whether to assert PTT or release PTT on the pin.
+// • WSJT-X station = this WSJT-X station (app + PC + radio + antenna).
+//
+// Child of HamlibTransceiver on the transceiver thread (stock CAT order).
+//
+// Design authority / glossary: docs/TX_INHIBIT.md
+// SPDX-License-Identifier: GPL-3.0-or-later
+// ---------------------------------------------------------------------------
+
+#include <QElapsedTimer>
+#include <QObject>
+#include <QString>
+
+#include "TxInhibitLogic.hpp"
+
+class QUdpSocket;
+class QTimer;
+
+class TxInhibitGate
+  : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit TxInhibitGate (QObject * parent = nullptr);
+  ~TxInhibitGate () override;
+
+public slots:
+  // Bind UDP + start hold-timeout poll timer (once on transceiver thread).
+  void start_listening ();
+
+  // WSJT-X TX intent from do_ptt(on). Does not take "hold" as an argument;
+  // hold is private. Physical line is driven via physicalPtt(radiate).
+  void set_intent (bool on);
+
+  // Force intent off, stop UDP/timer (rig close / shutdown).
+  // If emit_pin is false, do not request a physical PTT change (caller already
+  // closed Hamlib or will set the pin itself). Safe to call more than once.
+  void shutdown (bool emit_pin = true);
+
+signals:
+  // Ask HamlibTransceiver to call rig_set_ptt (radiate true/false).
+  // Same thread (DirectConnection) when parent is HamlibTransceiver.
+  void physicalPtt (bool radiate);
+
+  // Queued to GUI: status-bar badge + optional InhibitStatus counters.
+  void inhibitChanged (bool inhibited, QString const& source
+                       , quint32 hold_rx, quint32 release_rx
+                       , quint32 expiries, quint32 invalid);
+
+  // Bound UDP port (22372 or ephemeral).
+  void portBound (quint16 port);
+
+  // Non-fatal operator-visible problems (e.g. total UDP bind failure).
+  // Callers must not treat this as a rig CAT/PTT failure.
+  void lineError (QString const& message);
+
+private slots:
+  void on_udp_ready ();
+  void tick ();
+
+private:
+  // Returns true if UDP is listening (preferred or ephemeral port).
+  bool ensure_udp ();
+  void apply_line ();
+  // Emits physicalPtt with exceptions contained. The slot on the other end
+  // calls rig_set_ptt, which throws; this is reached from timer and socket
+  // slots where an escaping exception would abort the application.
+  void emit_physical_ptt (bool radiate);
+  void emit_state_if_changed ();
+  qint64 now_ms () const;
+
+  // Monotonic time base for hold expiry: immune to system-clock steps, which
+  // WSJT-X hosts take routinely from time-sync tools. See now_ms().
+  QElapsedTimer uptime_;
+  TxInhibit::GateLogic logic_;
+  QUdpSocket * udp_ {nullptr};
+  QTimer * timer_ {nullptr};
+  bool intent_ {false};
+  bool last_radiate_ {false};
+  bool last_emitted_inhibited_ {false};
+  bool stopped_ {false};         // after shutdown: no further pin emits
+  QString last_badge_;
+  quint16 bound_port_ {0};
+};
+
+#endif

--- a/TxInhibit/TxInhibitGate.hpp
+++ b/TxInhibit/TxInhibitGate.hpp
@@ -68,6 +68,11 @@ signals:
   // Callers must not treat this as a rig CAT/PTT failure.
   void lineError (QString const& message);
 
+  // rig_set_ptt failed while the gate was driving the pin. Unlike lineError
+  // (bind problems), this should surface as a rig/operator failure so the UI
+  // does not show "Tx" with no RF and no message.
+  void pttApplyFailed (QString const& message);
+
 private slots:
   void on_udp_ready ();
   void tick ();

--- a/TxInhibit/TxInhibitLogic.hpp
+++ b/TxInhibit/TxInhibitLogic.hpp
@@ -1,0 +1,234 @@
+#ifndef TX_INHIBIT_LOGIC_HPP__
+#define TX_INHIBIT_LOGIC_HPP__
+
+// ---------------------------------------------------------------------------
+// Pure, I/O-free TX Inhibit logic (parse + hold timeout)
+//
+// No sockets, no serial. Unit-testable; keep in sync with KEY-agent senders.
+//
+// Glossary: docs/TX_INHIBIT.md
+//
+//   assert PTT  ⇔  want_tx and not hold
+//
+//   WSJT-X station only: hold packets + hold_timeout_ms (wire ttl_ms) — safety
+//   timeout if keepalives stop. Agent hang (CW anti-chatter after release
+//   KEY, then release hold ttl_ms:0) is KEY-agent only — not here.
+//   See docs/TX_INHIBIT.md §3.1.
+//
+//   1. Datagram: ttl_ms>0 hold/keepalive (hold_timeout_ms); ttl_ms==0 release.
+//   2. hold active while now < hold_timeout_at_ms_.
+//   3. line_inhibited => must not assert PTT (UDP hold only; no local CTS).
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+// ---------------------------------------------------------------------------
+
+#include <QByteArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QString>
+#include <QtGlobal>
+
+namespace TxInhibit {
+
+// Project builds with --std=gnu++11 (-Werror); keep this header C++11-clean.
+static constexpr char const * protocol_key = "tx_inhibit";
+static constexpr int protocol_version = 1;
+// Well-known WSJT-X station listen / agent send port (IPv4). Ephemeral fallback is
+// handled by TxInhibitGate if bind fails.
+static constexpr quint16 default_gate_port = 22372;
+// Non-zero hold_timeout_ms (wire ttl_ms) must land in this range
+// (0 is reserved for release hold).
+static constexpr int hold_timeout_ms_min = 100;
+static constexpr int hold_timeout_ms_max = 30000;
+// Aliases for older call sites / tests.
+static constexpr int ttl_ms_min = hold_timeout_ms_min;
+static constexpr int ttl_ms_max = hold_timeout_ms_max;
+static constexpr int max_datagram_bytes = 512;
+
+// Parsed view of one KEY-agent UDP JSON body.
+// valid == false means "ignore this packet; do not change hold state."
+struct Datagram
+{
+  // Wire name ttl_ms; meaning hold_timeout_ms (>0) or 0 = release hold.
+  int ttl_ms {0};
+  QString station;      // badge: "held by …"
+  QString band;         // informational (WSJT-X station does not filter by band today)
+  qint64 seq {0};       // informational agent sequence
+  bool valid {false};
+};
+
+// Validate and unpack one UDP payload. On any failure returns valid=false
+// (empty Datagram) so callers can count invalids without partial updates.
+inline Datagram parse_datagram (QByteArray const& data)
+{
+  Datagram out;
+  if (data.isEmpty () || data.size () > max_datagram_bytes)
+    {
+      return out;
+    }
+  QJsonParseError err;
+  auto doc = QJsonDocument::fromJson (data, &err);
+  if (err.error != QJsonParseError::NoError || !doc.isObject ())
+    {
+      return out;
+    }
+  auto obj = doc.object ();
+  // Protocol id must be exactly protocol_version (currently 1).
+  if (obj.value (QLatin1String (protocol_key)).toInt (-1) != protocol_version)
+    {
+      return out;
+    }
+  // Accept JSON number (Qt stores as Double) or string digits (interop).
+  if (!obj.contains (QLatin1String ("ttl_ms")))
+    {
+      return out;
+    }
+  int ttl = -1;
+  {
+    auto const ttl_v = obj.value (QLatin1String ("ttl_ms"));
+    if (ttl_v.isDouble ())
+      {
+        ttl = ttl_v.toInt (-1);
+      }
+    else if (ttl_v.isString ())
+      {
+        bool ok = false;
+        ttl = ttl_v.toString ().toInt (&ok);
+        if (!ok)
+          {
+            return out;
+          }
+      }
+    else
+      {
+        return out;
+      }
+  }
+  // 0 = release hold; otherwise enforce hold_timeout_ms range.
+  if (ttl != 0 && (ttl < hold_timeout_ms_min || ttl > hold_timeout_ms_max))
+    {
+      return out;
+    }
+  out.ttl_ms = ttl; // hold_timeout_ms
+  out.station = obj.value (QLatin1String ("station")).toString ();
+  out.band = obj.value (QLatin1String ("band")).toString ();
+  out.seq = static_cast<qint64> (obj.value (QLatin1String ("seq")).toDouble (0));
+  out.valid = true;
+  return out;
+}
+
+// One UDP hold at a time. Last valid hold wins.
+// now_ms is supplied by the caller (same time base as hold_timeout_at_ms_).
+class GateLogic
+{
+public:
+  // Apply one hold/release packet to the UDP-hold state machine.
+  //
+  // Updates hold timeout from the datagram; does not touch serial lines or
+  // want_tx (those live in TxInhibitGate).
+  //
+  // Return value (important):
+  //   true  = the hold *level* flipped (free↔held), i.e.
+  //           inhibited(now) after != inhibited(now) before.
+  //   false = level unchanged — including keepalives that only refresh
+  //           hold_timeout_ms, invalid packets, and redundant releases.
+  //
+  // This is NOT "datagram says hold" (a hold while already held returns
+  // false). It is NOT "RTS/DTR changed" (see line_inhibited / apply_line).
+  // Callers may ignore the return and re-evaluate line_inhibited() instead;
+  // TxInhibitGate does exactly that today.
+  bool on_datagram (QByteArray const& data, qint64 now_ms)
+  {
+    auto msg = parse_datagram (data);
+    if (!msg.valid)
+      {
+        ++invalid_;
+        return false; // no state change
+      }
+    // Snapshot hold level *before* mutating hold timeout.
+    bool before = inhibited (now_ms);
+    if (msg.ttl_ms == 0)
+      {
+        // Explicit release hold (ttl_ms == 0; normal end after agent hang).
+        ++release_rx_;
+        hold_timeout_at_ms_ = -1;
+      }
+    else
+      {
+        // Hold or keepalive: set hold_timeout_ms and re-arm expiry.
+        ++hold_rx_;
+        hold_timeout_at_ms_ = now_ms + msg.ttl_ms;
+        holder_ = msg.station;
+      }
+    return inhibited (now_ms) != before;
+  }
+
+  // Hold active? Also applies hold timeout: if it has passed, clear hold
+  // and count an expiry (includes deadman / agent silence).
+  // Side effect on expiry is intentional so a 50 Hz poll can clear hold
+  // without another packet.
+  bool inhibited (qint64 now_ms)
+  {
+    if (hold_timeout_at_ms_ >= 0 && now_ms >= hold_timeout_at_ms_)
+      {
+        hold_timeout_at_ms_ = -1;
+        ++expiries_;
+      }
+    return hold_timeout_at_ms_ >= 0;
+  }
+
+  // Station string for the badge while a hold is active; empty if none.
+  QString holding_station (qint64 now_ms)
+  {
+    return inhibited (now_ms) ? holder_ : QString {};
+  }
+
+  // True => must not assert PTT (regardless of want_tx).
+  // UDP hold only (no local CTS in this build).
+  bool line_inhibited (qint64 now_ms)
+  {
+    return inhibited (now_ms);
+  }
+
+  // Pin formula (unit-test friendly): assert PTT ⇔ want_tx && !hold.
+  bool radiate (bool intent, qint64 now_ms)
+  {
+    return intent && !line_inhibited (now_ms);
+  }
+
+  // Status-bar text; empty means no hold (hide the badge).
+  QString badge_text (qint64 now_ms)
+  {
+    if (inhibited (now_ms))
+      {
+        auto s = holding_station (now_ms);
+        if (s.isEmpty ())
+          {
+            return QStringLiteral ("TX INHIBITED");
+          }
+        return QStringLiteral ("TX INHIBITED — held by %1").arg (s);
+      }
+    return {};
+  }
+
+  // Diagnostics (optional telemetry / InhibitStatus).
+  quint32 hold_rx () const { return hold_rx_; }
+  quint32 release_rx () const { return release_rx_; }
+  quint32 expiries () const { return expiries_; }
+  quint32 invalid () const { return invalid_; }
+
+private:
+  // Absolute time when the current hold ends (same epoch as now_ms args).
+  // -1 means no hold. Set to now_ms + hold_timeout_ms (wire ttl_ms) on each
+  // hold/keepalive packet.
+  qint64 hold_timeout_at_ms_ {-1};
+  QString holder_;           // last hold's station field
+  quint32 hold_rx_ {0};
+  quint32 release_rx_ {0};
+  quint32 expiries_ {0};
+  quint32 invalid_ {0};
+};
+
+} // namespace TxInhibit
+
+#endif

--- a/docs/INHIBIT_AGENT.md
+++ b/docs/INHIBIT_AGENT.md
@@ -1,0 +1,117 @@
+# inhibit-agent — standalone KEY agent
+
+**Audience:** operators who use TX Inhibit on a dual-radio seat **without WIMS**.  
+**Scope:** this program only. Gate internals live in [TX_INHIBIT.md](TX_INHIBIT.md).
+
+**KEY agent** is the role. This program is the standalone KEY agent: the
+operator supplies the serial port and dest `host:port`. A WIMS
+deployment can instead use **`wims-key-agent`** (destinations from WIMS
+discovery). Same UDP protocol either way.
+
+Without a KEY agent the gate only accepts hold datagrams — it cannot
+see the SSB/CW KEY. Shipping this program is what makes TX Inhibit
+usable on a station that is not a WIMS station.
+
+---
+
+## 0. Inhibit generators (same wire protocol)
+
+| Program | Role |
+|---------|------|
+| **inhibit-agent** | **This program.** USB-serial **CTS** → hold. Operator setup. |
+| **wims-key-agent** | WIMS KEY agent (WIMS tree, not this program). Same protocol. |
+| **`tools/send_inhibit_hold.py`** | Lab / bench: scripted hold / release, no KEY dongle. |
+
+All speak the same `tx_inhibit` datagrams.
+
+**Name:** `inhibit-agent` (CLI) and `inhibit-agent-gui` (GUI). Linux and Windows.
+
+---
+
+## 1. Purpose
+
+Give **SSB/CW KEY priority over WSJT-X transmit** on a dual-radio station:
+
+1. Sense the SSB/CW **KEY** line on USB-serial **CTS**.
+2. While KEY is asserted, send **TX Inhibit hold** datagrams to the gate.
+3. On KEY release: **hang only for break-in CW**, then **release** (`ttl_ms: 0`).
+   Continuous KEY (SSB / PTT / non-break-in) releases **immediately**.
+   **No software PTT debounce** — the sense path is for **manual switches that
+   already debounce**.
+
+---
+
+## 2. Two forms
+
+| Form | Binary | Who | Required inputs |
+|------|--------|-----|-----------------|
+| **CLI** | `inhibit-agent` | Scripts, SSH, startup files | USB-serial **CTS** port and dest `host:port` |
+| **GUI** | `inhibit-agent-gui` | Operators | Dest **host:port** in the window (default `127.0.0.1:22372`). CTS port auto-picked or `--port`. |
+
+---
+
+## 3. CLI (scripting)
+
+```text
+inhibit-agent --port /dev/ttyUSB0 --addr 127.0.0.1:22372
+inhibit-agent --port COM7 --addr 192.168.1.40:22372
+inhibit-agent COM7 192.168.1.40:22372
+inhibit-agent --port COM7 --addr 127.0.0.1:22372 --invert
+inhibit-agent --list-ports
+```
+
+| Flag | Default | Notes |
+|------|---------|--------|
+| `--port` / first positional | **required** | COM / tty device (CTS = KEY) |
+| `--addr` / second positional | **required** | `host:port` of the WSJT-X gate |
+| `--invert` | false | CTS polarity |
+| `--ttl-ms` | `600` | Wire hold timeout (not hang) |
+
+Stdout is timestamped `STATE` / `HOLD` / `RELEASE` / `SENSE FAULT` lines. Ctrl-C
+sends release then exits (fail-safe: if the process dies, gate deadman also
+clears).
+
+---
+
+## 4. GUI (operators)
+
+Double-click `inhibit-agent-gui` (Windows) or run it from the install `bin/`
+(Linux). It:
+
+1. Prefers a serial device whose USB strings look like **Keyline** / **WA1HCO**.
+2. Else uses the only non-builtin USB-serial port.
+3. **Gate** field is dest `host:port`, default **`127.0.0.1:22372`**. Apply to change.
+4. Shows **OPEN** / **INHIBITING** / **HANG** / **SENSE FAULT** in a large badge.
+
+Usual same-PC seat: leave Gate at localhost; only the CTS port is auto-picked.
+
+---
+
+## 5. Hang
+
+Same KEYing monitor as the design in [TX_INHIBIT.md](TX_INHIBIT.md) §3:
+
+- Break-in CW: hang = **1.5 × word gap** (10.5 × dit), clamp 315–1260 ms.
+- Continuous KEY / SSB: hang = **0**.
+
+Hang exists only so WSJT-X PTT does not follow CW dits.
+
+---
+
+## 6. Wire identity
+
+| Field | Value |
+|-------|--------|
+| `station` | `inhibit-agent` |
+| `band` | `local` |
+
+Not used for routing. Diagnostics / badge only.
+
+---
+
+## 7. Fail-safe
+
+If the agent stops or the dongle disappears, keepalives stop. The gate deadman
+(~600 ms) opens. Prefer a brief unprotected window over a stuck inhibit.
+
+Wrong or missing COM is **SENSE FAULT**, never silent protection.

--- a/docs/INHIBIT_AGENT.md
+++ b/docs/INHIBIT_AGENT.md
@@ -115,3 +115,13 @@ If the agent stops or the dongle disappears, keepalives stop. The gate deadman
 (~600 ms) opens. Prefer a brief unprotected window over a stuck inhibit.
 
 Wrong or missing COM is **SENSE FAULT**, never silent protection.
+
+**RTS/DTR stay idle.** This program only reads **CTS**. It never keys or
+inhibits via RTS. USB-serial drivers (and Qt) assert RTS+DTR on open, and
+restoring termios on close can leave RTS high with **no WSJT-X or WIMS
+running** — that keys a radio on Keyline J3. The agent forces RTS+DTR off
+immediately after open, keeps them off, disables hangup-on-close, and does
+not restore the driver’s default lines when it exits.
+
+Linux: ModemManager will open a new USB-serial and assert RTS. Ignore the
+Keyline with the udev rule in `tools/inhibit-agent/99-keyline-not-modem.rules`.

--- a/docs/TX_INHIBIT.md
+++ b/docs/TX_INHIBIT.md
@@ -150,6 +150,7 @@ path when several apps share the station.
 |---------|--------|-----|
 | Flaky CAT / stuck TX | RTS used as handshake | Handshake **None**; radio SEND not flow control |
 | Keys on port open | Polarity / forced DTR-RTS | Check logger forced lines; try other modem line |
+| Keys with no WSJT-X / WIMS | USB-serial default RTS (open/close or ModemManager) | `inhibit-agent` now forces RTS+DTR idle; Linux udev: `tools/inhibit-agent/99-keyline-not-modem.rules` |
 | “Worked yesterday” | Another app owns COM | One owner; restart after other apps close |
 | Test PTT OK, no RF | Often audio/mode | DATA mode, levels, power meter |
 | CW key instead of PTT | Icom USB Keying vs USB SEND | PTT → **USB SEND** |

--- a/docs/TX_INHIBIT.md
+++ b/docs/TX_INHIBIT.md
@@ -459,41 +459,34 @@ Enable TX Inhibit, RTS/DTR on a real serial port, then send the same UDP a KEY
 agent would (default **127.0.0.1:22372**). Expect red **TX INHIBITED**; WSJT-X station
 does not **assert PTT** while hold is active.
 
-### `inhibit-test` / `inhibit-test-gui` (KEY-agent stand-ins)
+### `inhibit-test` (KEY-agent stand-in)
 
-| Binary | Platform | Notes |
-|--------|----------|--------|
-| **`inhibit-test`** | Linux / Windows console | Canonical CLI (Qt). |
-| **`inhibit-test-gui`** | Windows GUI | Native Win32; mouse or grave; same protocol. |
-
-Implements §3 (Hold sender + KEYing monitor):
+Console KEY stand-in. Implements §3 (Hold sender + KEYing monitor):
 
 | Action | Effect |
 |--------|--------|
-| **` (grave) down** (or GUI button) | **assert KEY** → hold (`ttl_ms`=hold_timeout) + keepalives |
-| **` up** / button up | KEY open → hang per §3.2, then **release hold** (`ttl_ms: 0`) after hang |
+| **` (grave) down** | **assert KEY** → hold (`ttl_ms`=hold_timeout) + keepalives |
+| **` up** | KEY open → hang per §3.2, then **release hold** (`ttl_ms: 0`) after hang |
 | **`~` (shift+grave)** | **Latch on** — hold stays asserted after key release, so the keyboard is free to drive WSJT-X. Reads as continuous KEY (hang 0). Press `` ` `` or `~` again to clear; `` ` `` always clears the latch. |
-| **q** / **Esc** / Force RELEASE | cancel keepalives, **release hold** (quit on console) |
+| **q** / **Esc** | cancel keepalives, **release hold**, quit |
 
 **KEY key is grave/backtick `` ` ``** (left of `1` on US keyboards) — **not Space**.
 Unshifted `` ` `` is momentary; **`~` (shifted) latches** the hold on until either key
 is pressed again.
 
 Hang policy (default): break-in **1.5× word gap** from measured dit; continuous
-KEY (long mark ≥500 ms) **hang = 0**. Override: `--fixed-hang-ms` (console) or
-**fixed hang ms** field (GUI).
+KEY (long mark ≥500 ms) **hang = 0**. Override: `--fixed-hang-ms`.
 
 ```text
 inhibit-test --host 127.0.0.1 --port 22372 --station TEST-KEY --ttl-ms 600
 inhibit-test --fixed-hang-ms 0
-bin\inhibit-test-gui.exe
 ```
 
 If the WSJT-X station bound an ephemeral port, pass that `--port`.
 
-**Input focus:** console default = this terminal only (`--global-keys` = system-wide).
-GUI = keys only while the GUI window is focused. **Linux console:** group
-`input` required for `/dev/input`; without it **`inhibit-test` refuses to start**.
+**Input focus:** default = this terminal only (`--global-keys` = system-wide).
+**Linux:** group `input` required for `/dev/input`; without it **`inhibit-test`
+refuses to start**.
 
 **Digi RF checks:** hold `` ` `` ≥500 ms (continuous, hang 0) or fixed hang 0.
 
@@ -519,7 +512,7 @@ Operator checklist: [INSTALL.md §6](../INSTALL.md#6-test-tx-inhibit-with-the-ke
 | Settings **Enable TX Inhibit** + signals | `Configuration.{hpp,cpp,ui}` |
 | Status badge + `InhibitStatus` | `widgets/mainwindow.cpp` |
 | MessageClient type 17 | `Network/NetworkMessage.hpp`, `MessageClient` |
-| KEY-agent stand-in | **`inhibit-test`** (`tools/inhibit-test/`); Windows **`inhibit-test-gui`** (`tools/inhibit_spacebar/`); `send_inhibit_hold.py` |
+| KEY-agent stand-in | **`inhibit-test`** (`tools/inhibit-test/`); `send_inhibit_hold.py` |
 
 **Maintainer notes (algorithm)**
 

--- a/docs/TX_INHIBIT.md
+++ b/docs/TX_INHIBIT.md
@@ -12,7 +12,10 @@ Design authority for this repository: how **wsjtx-inhibit** implements
 
 | Term | Meaning |
 |------|---------|
-| **WSJT-X station** | One digi position: this app + PC + network + radio + antenna (CAT/PTT). Multi-op has several. May be an unattended go-box, remote from the priority SSB/CW station and KEY agent. |
+| **WSJT-X station** | One digi position: this app + PC + network + radio + antenna (CAT/PTT). Multi-op has several. May be an unattended go-box, remote from the priority SSB/CW station and the KEY agent. |
+| **KEY agent** | Role: any process that sees the priority KEY and sends hold / keepalive / **release hold**. Not a binary name. |
+| **`inhibit-agent`** | Standalone KEY agent in this tree. Operator supplies the serial port and dest `host:port`. [INHIBIT_AGENT.md](INHIBIT_AGENT.md). Makes TX Inhibit usable **without WIMS**. |
+| **`wims-key-agent`** | WIMS KEY agent (WIMS tree, not this repo). Destinations come from WIMS discovery. Same protocol. |
 | **TX Inhibit** | Product / feature name (Settings, badge, this build). |
 | **want_tx** | Software wants to transmit (FT8 sequence, “Enable Tx”, audio path). |
 | **hold** | KEY agent has told WSJT-X stations not to transmit (UDP timed request active). |
@@ -58,11 +61,17 @@ Wire format: JSON fields `tx_inhibit`, `ttl_ms`, … (§4). No hang field.
 
 | Role | Where | Job |
 |------|--------|-----|
-| **WSJT-X station** (wsjtx-inhibit) | App + PC + network + radio + antenna (may be remote go-box) | When TX Inhibit is enabled and PTT is RTS/DTR: apply the equation (when may this station **assert PTT**). |
-| **KEY agent** | Process that sees the priority radio’s KEY (often near SSB/CW / WIMS server) | While KEY is asserted (and during agent **hang** after **release KEY**), sends hold keepalives; when hang finishes, **releases hold** (`ttl_ms: 0`). |
-| **Bench helper** | Same PC or LAN | **`inhibit-test`** (canonical KEY-agent stand-in) or `tools/send_inhibit_hold.py`. |
+| **WSJT-X station** | App + PC + network + radio + antenna (may be remote go-box) | When TX Inhibit is enabled and PTT is RTS/DTR: apply the equation (when may this station **assert PTT**). |
+| **KEY agent** | Process that sees the priority radio’s KEY | While KEY is asserted (and during agent **hang** after **release KEY**), sends hold keepalives; when hang finishes, **releases hold** (`ttl_ms: 0`). |
 
-Any program that speaks §4 is a valid KEY agent.
+Any program that speaks §4 is a valid KEY agent. This tree ships a standalone
+agent so a dual-radio seat works **without WIMS**:
+
+| Program | Tree | Setup |
+|---------|------|--------|
+| **`inhibit-agent`** / **`inhibit-agent-gui`** | this tree | Operator supplies USB-serial CTS and dest `host:port`. [INHIBIT_AGENT.md](INHIBIT_AGENT.md). |
+| **`wims-key-agent`** | WIMS | Same role; destinations from WIMS discovery. Not shipped here. |
+| **`send_inhibit_hold.py`** | this tree | Scripted bench hold / release. |
 
 ```text
   Priority radio
@@ -350,9 +359,9 @@ hold timeout and look like a stuck hold.
 
 | Input | Notes |
 |-------|--------|
-| USB-serial **CTS** (or other pin) | KEY → interface → CTS; event-driven if possible |
+| USB-serial **CTS** (or other pin) | KEY → interface → CTS. This is what **`inhibit-agent`** reads. |
 | GPIO / other | Agent-specific |
-| Manual / test | Grave/backtick **`** KEY — `inhibit-test` / `tools/send_inhibit_hold.py --interactive` |
+| Manual / test | `tools/send_inhibit_hold.py --interactive` |
 
 Debounce and **hang** (anti-chatter) live in the agent. The WSJT-X station applies only
 **hold timeout** (safety) so a **deadman** cannot leave a hold stuck forever.
@@ -447,9 +456,9 @@ needs them; neither is implemented, so do not assume either.
 **Decision:** no CTS in the WSJT-X station binary. **UDP hold only** + RTS/DTR PTT.
 
 **Why:** floating/driven CTS caused intermittent false hold. Worse than
-requiring a KEY agent (or the `inhibit-test` helper) on UDP.
+requiring a KEY agent (`inhibit-agent`) on UDP.
 
-Until CTS is opt-in and safe: KEY agent → UDP, or localhost helper.
+Until CTS is opt-in and safe: KEY agent → UDP.
 
 ---
 
@@ -459,46 +468,29 @@ Enable TX Inhibit, RTS/DTR on a real serial port, then send the same UDP a KEY
 agent would (default **127.0.0.1:22372**). Expect red **TX INHIBITED**; WSJT-X station
 does not **assert PTT** while hold is active.
 
-### `inhibit-test` (KEY-agent stand-in)
+### KEY agent (`inhibit-agent` / `inhibit-agent-gui`)
 
-Console KEY stand-in. Implements §3 (Hold sender + KEYing monitor):
-
-| Action | Effect |
-|--------|--------|
-| **` (grave) down** | **assert KEY** → hold (`ttl_ms`=hold_timeout) + keepalives |
-| **` up** | KEY open → hang per §3.2, then **release hold** (`ttl_ms: 0`) after hang |
-| **`~` (shift+grave)** | **Latch on** — hold stays asserted after key release, so the keyboard is free to drive WSJT-X. Reads as continuous KEY (hang 0). Press `` ` `` or `~` again to clear; `` ` `` always clears the latch. |
-| **q** / **Esc** | cancel keepalives, **release hold**, quit |
-
-**KEY key is grave/backtick `` ` ``** (left of `1` on US keyboards) — **not Space**.
-Unshifted `` ` `` is momentary; **`~` (shifted) latches** the hold on until either key
-is pressed again.
-
-Hang policy (default): break-in **1.5× word gap** from measured dit; continuous
-KEY (long mark ≥500 ms) **hang = 0**. Override: `--fixed-hang-ms`.
+Standalone KEY agent so TX Inhibit works **without WIMS**. USB-serial CTS
+in, dest `host:port` out. Design: [INHIBIT_AGENT.md](INHIBIT_AGENT.md).
 
 ```text
-inhibit-test --host 127.0.0.1 --port 22372 --station TEST-KEY --ttl-ms 600
-inhibit-test --fixed-hang-ms 0
+inhibit-agent --port /dev/ttyUSB0 --addr 127.0.0.1:22372
+inhibit-agent COM7 192.168.1.40:22372
+inhibit-agent-gui
 ```
 
-If the WSJT-X station bound an ephemeral port, pass that `--port`.
-
-**Input focus:** default = this terminal only (`--global-keys` = system-wide).
-**Linux:** group `input` required for `/dev/input`; without it **`inhibit-test`
-refuses to start**.
-
-**Digi RF checks:** hold `` ` `` ≥500 ms (continuous, hang 0) or fixed hang 0.
+Hang policy (default): break-in **1.5× word gap** from measured dit;
+continuous KEY (long mark ≥500 ms) **hang = 0**.
 
 ### Python: `tools/send_inhibit_hold.py`
+
+Scripted hold / release with no KEY dongle:
 
 ```bash
 python3 tools/send_inhibit_hold.py --interactive
 python3 tools/send_inhibit_hold.py --ttl-ms 3000 --station TEST
 python3 tools/send_inhibit_hold.py --ttl-ms 0
 ```
-
-Operator checklist: [INSTALL.md §6](../INSTALL.md#6-test-tx-inhibit-with-the-key-helper-inhibit-test).
 
 ---
 
@@ -512,7 +504,7 @@ Operator checklist: [INSTALL.md §6](../INSTALL.md#6-test-tx-inhibit-with-the-ke
 | Settings **Enable TX Inhibit** + signals | `Configuration.{hpp,cpp,ui}` |
 | Status badge + `InhibitStatus` | `widgets/mainwindow.cpp` |
 | MessageClient type 17 | `Network/NetworkMessage.hpp`, `MessageClient` |
-| KEY-agent stand-in | **`inhibit-test`** (`tools/inhibit-test/`); `send_inhibit_hold.py` |
+| Standalone KEY agent | **`inhibit-agent`** / **`inhibit-agent-gui`** (`tools/inhibit-agent/`); `send_inhibit_hold.py` |
 
 **Maintainer notes (algorithm)**
 

--- a/docs/TX_INHIBIT.md
+++ b/docs/TX_INHIBIT.md
@@ -1,0 +1,535 @@
+# TX Inhibit and KEY agent
+
+Design authority for this repository: how **wsjtx-inhibit** implements
+**TX Inhibit**, and how a **KEY agent** drives it.
+
+**Operators (install / KEY test):** [INSTALL.md](../INSTALL.md)  
+**Code map:** §7
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **WSJT-X station** | One digi position: this app + PC + network + radio + antenna (CAT/PTT). Multi-op has several. May be an unattended go-box, remote from the priority SSB/CW station and KEY agent. |
+| **TX Inhibit** | Product / feature name (Settings, badge, this build). |
+| **want_tx** | Software wants to transmit (FT8 sequence, “Enable Tx”, audio path). |
+| **hold** | KEY agent has told WSJT-X stations not to transmit (UDP timed request active). |
+| **assert PTT** / **release PTT** | Physical PTT line active / inactive (RTS/DTR as configured). Same pattern for KEY: **assert KEY** / **release KEY**. |
+| **release hold** | Explicit end of the hold: UDP packet with `ttl_ms: 0`. Current algorithm ends holds this way (not by waiting for WSJT-X station hold timeout alone). |
+| **hang** / anti-chatter (KEY agent only) | After last KEY open, how long break-in CW keeps renewing hold before **release hold**. **1.5 × word gap** at measured WPM (≥ 10 WPM). Non-break-in CW / SSB: hang **0** (release on KEY open). Not in the WSJT-X station; no wire field. |
+| **hold timeout** / `hold_timeout_ms` (WSJT-X station / TX Inhibit) | **Safety** timer only: how long the station keeps a hold without a new packet. Wire `ttl_ms` (~500–600 ms); keepalives ~200 ms. Not hang; not CW speed. |
+| **deadman** | Agent stops without finishing hang and **release hold** (crash, kill, path loss). The WSJT-X station **hold timeout** then ends the hold. |
+| **TxInhibit module** | Code under `TxInhibit/` plus the pin filter in `HamlibTransceiver`. |
+
+**Core equation**
+
+```text
+assert PTT  ⇔  want_tx  and  not hold
+```
+
+The KEY agent **tells WSJT-X stations not to transmit**; while a hold is active, the
+WSJT-X station will not **assert PTT** even if `want_tx` is true.
+
+**Two different timers — different purpose, different time scale**
+
+| Timer | Where | Purpose | Typical scale |
+|-------|--------|---------|----------------|
+| **Hang** (anti-chatter) | KEY agent (KEYing monitor) | Break-in CW: keep hold across gaps; EOT after KEY open **&gt; 1.5× word gap**. Non-break-in / SSB: hang 0, EOT on KEY open. | **1.5 × 7 dits** at measured WPM (see §3.4). |
+| **Hold timeout** | WSJT-X station only | Survive **loss of hold messages**. | **`hold_timeout_ms` ≈ 500–600 ms**; renew **~200 ms**. Independent of WPM. |
+
+These are not interchangeable. Hang is CW/operator policy. Hold timeout is
+UDP reliability / fail-open safety.
+
+**History vs current algorithm.** Early designs leaned on timers alone to drop
+the hold. The **current** algorithm **explicitly ends** the hold with
+**release hold** (`ttl_ms: 0`) when agent hang finishes. Station
+`hold_timeout_ms` is only the safety path (including deadman).
+
+**Not the same as radio “TX Inhibit” menus.** Many rigs latch inhibit until
+PTT drops. Sequencing continues (unlike **Halt Tx**).
+
+Wire format: JSON fields `tx_inhibit`, `ttl_ms`, … (§4). No hang field.
+
+---
+
+## 1. Roles
+
+| Role | Where | Job |
+|------|--------|-----|
+| **WSJT-X station** (wsjtx-inhibit) | App + PC + network + radio + antenna (may be remote go-box) | When TX Inhibit is enabled and PTT is RTS/DTR: apply the equation (when may this station **assert PTT**). |
+| **KEY agent** | Process that sees the priority radio’s KEY (often near SSB/CW / WIMS server) | While KEY is asserted (and during agent **hang** after **release KEY**), sends hold keepalives; when hang finishes, **releases hold** (`ttl_ms: 0`). |
+| **Bench helper** | Same PC or LAN | **`inhibit-test`** (canonical KEY-agent stand-in) or `tools/send_inhibit_hold.py`. |
+
+Any program that speaks §4 is a valid KEY agent.
+
+```text
+  Priority radio
+       │ KEY sense
+       ▼
+  ┌───────────┐     “don’t transmit” / keepalive / release hold (UDP)
+  │ KEY agent │ ────────────────────────────────────────────────────┐
+  └───────────┘                                                     │
+                                                                    ▼
+  want_tx ──► │  TxInhibit filter  │ ── RTS/DTR ──► radio PTT
+              │  assert PTT ⇔        │
+              │    want_tx and not hold │
+              └────────────────────┘
+```
+
+The hold request is **UDP only**. Local CTS KEY on the WSJT-X station PTT dongle is
+**out of this build** (§5).
+
+---
+
+## 2. WSJT-X station behaviour (this program)
+
+A **WSJT-X station** is one digi position: this program, PC, network, radio, and antenna
+(CAT/PTT path). It may be unattended (e.g. a go-box) and remote from the priority
+SSB/CW station and the KEY agent host.
+
+- **Opt-in.** Settings → Radio → **Enable TX Inhibit**. Default **off**
+  (stock WSJT-X PTT). Requires **PTT method** = RTS or DTR.
+- **Sequencing and audio stay the same.** TX Inhibit only decides whether the
+  WSJT-X station may **assert PTT** when the KEY agent has said not to transmit.
+- **Equation:** `assert PTT ⇔ want_tx and not hold`.
+- **hold** is active while an unexpired **hold timeout** is set (KEY agent or
+  test tool).
+- Default listen port: **22372** (IPv4). If busy, an **ephemeral** port is
+  used (status-bar tooltip / `InhibitStatus`). Prefer free 22372. Total bind
+  failure is **non-fatal**: CAT/PTT continue; hold requests are not received.
+- Status bar (red): `TX INHIBITED` or `TX INHIBITED — held by <station>`.
+
+### Setup summary
+
+1. **PTT method** = **RTS** or **DTR**.
+2. **Enable TX Inhibit** = checked.
+3. **PTT port** = real serial device (`COMx` / `/dev/ttyUSBx`), same COM as
+   CAT if shared, or a separate PTT adapter. List value **CAT** is OmniRig-style
+   proxy only — Hamlib still needs a real device name for RTS/DTR.
+4. Wire RTS/DTR → radio PTT/SEND (or USB SEND / PC KEYING). Radio **VOX** off
+   for clean tests.
+5. Point the KEY agent at this WSJT-X station host:port (usually `22372`).
+
+### Shared USB CAT + RTS/DTR
+
+Many contest radios expose **one USB** with CAT on a virtual COM and
+**RTS/DTR** mappable to PTT. Shared COM is normal when Handshake is **None**
+and the radio maps the line to SEND/PTT (not flow control).
+
+**Implementation:** Hamlib owns the serial port (one fd for shared CAT+PTT).
+The TxInhibit module does **not** open a second serial handle. It only
+filters whether `do_ptt` may **assert PTT**.
+
+Also common: CAT-only PTT (not filtered by TX Inhibit), or a second keyline
+path when several apps share the station.
+
+#### Brands (USB RTS/DTR → radio PTT?)
+
+| Brand | USB RTS/DTR can key TX? | Notes |
+|-------|-------------------------|--------|
+| **Icom** (7300, 7610, 705, …) | **Yes** | **USB SEND** = RTS or DTR (PTT). |
+| **Elecraft** (K3S, K4, …) | **Yes** | USB RTS/DTR → PTT / KEY / FSK. |
+| **Yaesu** (FTDX10, FT-710, …) | **Yes (usual)** | **PC KEYING** = RTS/DTR; CAT RTS handshake **OFF**. |
+| **Kenwood** (TS-590SG, …) | **Usually no on built-in USB** | Hardware PTT often ACC; external USB-serial common. |
+| **FlexRadio** | **Not classic USB SEND** | Virtual COM / SmartSDR models differ. |
+
+#### Common setup problems
+
+| Symptom | Cause | Try |
+|---------|--------|-----|
+| Flaky CAT / stuck TX | RTS used as handshake | Handshake **None**; radio SEND not flow control |
+| Keys on port open | Polarity / forced DTR-RTS | Check logger forced lines; try other modem line |
+| “Worked yesterday” | Another app owns COM | One owner; restart after other apps close |
+| Test PTT OK, no RF | Often audio/mode | DATA mode, levels, power meter |
+| CW key instead of PTT | Icom USB Keying vs USB SEND | PTT → **USB SEND** |
+| Port-open TX blip | Driver toggles DTR/RTS | Known with some USB-serial chips |
+| Multi-app contest mess | Two apps key same lines | Logger digi / port-handoff rules |
+| “TX Inhibit never stops PTT” | CAT-only PTT, or feature off | **Enable TX Inhibit** + RTS/DTR |
+
+#### WSJT-X station options
+
+| Option | Notes |
+|--------|--------|
+| Same USB COM for CAT + RTS/DTR | Supported when menus match checklist |
+| Separate USB-serial for PTT | Fine |
+| CAT PTT only | Not filtered — use RTS/DTR for TX Inhibit |
+| Kenwood / Flex | Plan external keyline or Flex’s model |
+
+**Shared-cable checklist**
+
+1. Handshake **None**.  
+2. Radio: line = USB SEND / PC KEYING / PTT, not flow control.  
+3. **PTT method** = RTS or DTR.  
+4. **Enable TX Inhibit** checked.  
+5. **PTT port** = same real COM as CAT (not list value “CAT”).  
+6. One program owns the modem lines.  
+7. Confirm with **Test PTT** and RF/ALC, not only “CAT green.”
+
+---
+
+## 3. KEY agent
+
+The KEY agent reads the priority **KEY** line and runs **two parallel state
+machines** that meet only at **end of transmission**.
+
+| State machine | On KEY assert (start) | Ongoing | End of transmission |
+|---------------|----------------------|---------|---------------------|
+| **Hold sender** | Send **hold** immediately with `ttl_ms` = **hold_timeout_ms** (~500–600 ms safety window) | **Keepalives** ~every 200 ms while hold is active | On signal from KEYing monitor: send **release hold** (`ttl_ms: 0`) |
+| **KEYing monitor** | Start KEY timing assessment | Classify break-in CW vs continuous KEY (non-break-in CW / SSB); measure CW speed if break-in | Decide **when** the KEY sequence is over; signal Hold sender to release |
+
+Hold sender does **not** guess CW. KEYing monitor does **not** send UDP.
+Only Hold sender emits packets; only KEYing monitor decides release timing.
+
+### 3.1 Two timers (again): hang vs hold timeout
+
+| | **Hang (anti-chatter)** | **Hold timeout (safety)** |
+|--|-------------------------|---------------------------|
+| Owner | KEY agent (KEYing monitor) | WSJT-X station (from each hold packet) |
+| Purpose | CW **break-in**: keep hold across element/letter gaps so co-band PTT does not chatter | Survive **lost hold UDP**; fail-open if agent dies |
+| Sized by | **1.5 × word gap** at measured CW speed (≥ 10 WPM) | Keepalive period + margin (**~500–600 ms**); renew **~200 ms** |
+| On wire | No | Yes: `ttl_ms` = `hold_timeout_ms` |
+| End of hold | Monitor says EOT → Hold sender sends `ttl_ms: 0` | No packet before timeout |
+
+Do **not** size hang from hold timeout, or hold timeout from WPM.
+
+### 3.2 KEY classes and when transmission ends
+
+| KEY class | What KEY looks like | Hang after KEY open | End of transmission (EOT) |
+|-----------|---------------------|---------------------|---------------------------|
+| **Break-in CW** | KEY opens between dits/dahs (element / letter gaps visible) | **1.5 × word gap** at measured WPM (WPM from 10 upward) | KEY stays **open** longer than hang (i.e. longer than 1.5× word gap) |
+| **Non-break-in CW** | KEY continuous for whole send (no gaps on KEY sense) | **0** | **Immediately** on **release KEY** |
+| **SSB** (and similar) | KEY continuous for whole send | **0** | **Immediately** on **release KEY** |
+
+KEYing monitor classifies the stream, then uses that class for EOT. On EOT it
+signals Hold sender → **release hold** (`ttl_ms: 0`). That packet may fire
+**before** the first keepalive would have been scheduled (short continuous KEY).
+
+### 3.3 Morse timing baseline (Paris)
+
+| Quantity | Units (dits) | Time at W WPM |
+|----------|--------------|---------------|
+| Dit | 1 | \(T_\mathrm{dit} = 1200 / W\) ms |
+| Dah | 3 | \(3\,T_\mathrm{dit}\) |
+| Element gap (dit–dah inside a letter) | 1 | \(T_\mathrm{dit}\) |
+| Letter gap | 3 | \(3\,T_\mathrm{dit}\) |
+| **Word gap** | **7** | \(7\,T_\mathrm{dit}\) |
+| **Hang (break-in)** | **1.5 × word gap = 10.5** | \(1.5 \times 7\,T_\mathrm{dit} = 10.5\,T_\mathrm{dit}\) |
+
+### 3.4 Timelines by WPM — break-in vs non-break-in
+
+#### Morse unit times and hang (break-in)
+
+| WPM | Dit (ms) | Element gap (ms) | Letter gap (ms) | Word gap (ms) | Hang = 1.5× word gap (ms) |
+|-----|----------|------------------|-----------------|---------------|---------------------------|
+| 10 | 120 | 120 | 360 | 840 | **1260** |
+| 20 | 60 | 60 | 180 | 420 | **630** |
+| 30 | 40 | 40 | 120 | 280 | **420** |
+| 40 | 30 | 30 | 90 | 210 | **315** |
+
+Compare to **hold timeout ~500–600 ms** and **keepalive ~200 ms** (fixed safety
+path, same at all WPM): hang at 10–20 WPM is **longer** than one hold timeout;
+at 30–40 WPM hang is **shorter**. That is fine — keepalives re-arm hold timeout
+during hang; hang is not the safety timer.
+
+#### Break-in CW — example KEY open/close pattern
+
+```text
+  KEY:  █ █   █ █ █     █ …     (dits/dahs; opens between elements)
+  hold: |---- active, keepalives every ~200 ms ----|
+  on open longer than hang (1.5× word gap) → release hold (ttl_ms: 0)
+```
+
+#### Non-break-in CW / SSB — continuous KEY
+
+```text
+  KEY:  ████████████████████████    (no opens until the operator is done)
+  hold: |-- active --|
+  on first KEY open → hang = 0 → release hold (ttl_ms: 0) immediately
+```
+
+#### Hold active duration (from first KEY assert to release hold)
+
+**Break-in CW** (hang after last element):
+
+| Content (approx. Morse units) | 10 WPM | 20 WPM | 30 WPM | 40 WPM | Then hang (1.5× word) |
+|-------------------------------|--------|--------|--------|--------|------------------------|
+| Min assess **A** / **N** (5 u) | 0.60 s | 0.30 s | 0.20 s | 0.15 s | + hang table above |
+| **QRZ** (37 u) | 4.44 s | 2.22 s | 1.48 s | 1.11 s | + hang |
+| **THANK YOU** (85 u) | 10.2 s | 5.10 s | 3.40 s | 2.55 s | + hang |
+
+Hold stays up for **message time + hang**, then **`ttl_ms: 0`**.
+
+**Non-break-in CW / SSB** (same RF duration if continuous KEY for whole text):
+
+| Content | KEY-down duration (same unit totals if continuous) | Hang | Release |
+|---------|-----------------------------------------------------|------|---------|
+| As short as **QRZ** (~1.1–4.4 s by WPM if it were Morse-length) | One continuous KEY of that length (or whatever the operator holds) | **0** | On KEY open: **`ttl_ms: 0` immediately** |
+| **thank you** (~2.6–10 s Morse-equivalent if continuous) | Continuous KEY | **0** | Immediate **`ttl_ms: 0`** |
+
+### 3.5 Assessing KEY type and CW speed
+
+KEYing monitor runs **in parallel** with Hold sender (hold is already on).
+
+**Break-in CW assessment** needs visible structure:
+
+| Need to observe | Why |
+|-----------------|-----|
+| At least one **dit** | Short mark |
+| At least one **dah** | Long mark (~3× dit) |
+| At least one **element gap** (KEY open ~1 dit while still in character) | Proves break-in (gaps exist) |
+
+Minimum Morse pattern with dit + gap + dah: **A** (`·-`) or **N** (`-·`) = **5** dit units.
+
+| WPM | Max time to first assess-ready (5 units) |
+|-----|------------------------------------------|
+| 10 | **600 ms** |
+| 20 | **300 ms** |
+| 30 | **200 ms** |
+| 40 | **150 ms** |
+
+That is well under a full **QRZ** or **thank you**, and under the first
+keepalive interval in the slowest case only at 10 WPM (600 ms vs 200 ms
+keepalive — assessment can finish after a few keepalives; hold was already
+sent at t = 0).
+
+**Non-break-in CW / SSB:** KEY has **no gaps** until the end. Monitor never
+sees element gaps → classify continuous → hang = 0 → EOT on first KEY open.
+
+#### Distinguishability (QRZ … thank you)
+
+| Observation during a short call | Break-in CW | Non-break-in CW / SSB |
+|--------------------------------|-------------|------------------------|
+| KEY opens of ~1–3 dits **during** the send | Yes (many) | **No** |
+| KEY open ≥ hang (1.5× word gap) **before** EOT | No (that *is* EOT) | First open **is** EOT |
+| Continuous KEY for entire “QRZ” / “thank you” | No | Yes |
+
+Even **QRZ** at 40 WPM (~1.1 s of Morse structure) contains many element and
+letter gaps — clearly break-in. A continuous KEY of similar length with **zero**
+internal opens is clearly non-break-in / SSB. No reliance on hold timeout for
+this classification.
+
+### 3.6 Hold sender ↔ KEYing monitor (including race rules)
+
+```text
+  KEY assert
+      │
+      ├─► Hold sender:  send hold (ttl_ms = hold_timeout_ms) immediately
+      │                 schedule keepalives ~200 ms while hold_active
+      │
+      └─► KEYing monitor: sample KEY edges; classify; measure WPM if break-in
+                          decide EOT (hang rules above)
+                                │
+                                ▼
+                          signal Hold sender: END_HOLD
+                                │
+                                ▼
+                          Hold sender: stop keepalives, then send ttl_ms: 0
+```
+
+**Release may precede the first keepalive.** Example: non-break-in KEY down
+50 ms then up → hold at t = 0, release hold at t ≈ 50 ms; no keepalive sent.
+
+**No race between keepalive and `ttl_ms: 0`:**
+
+1. **Single sender path** — one goroutine/thread/queue owns all UDP hold
+   packets (keepalive and release).
+2. On **END_HOLD**: set `hold_active = false`, **cancel** pending keepalive
+   timer/work, **then** enqueue **release hold** (`ttl_ms: 0`).
+3. Keepalive loop must check `hold_active` **before** each send; after
+   END_HOLD, no further `ttl_ms > 0` packets.
+4. Optional belt-and-suspenders: ignore keepalives after a local release
+   generation counter increments.
+
+Never “fire keepalive and release concurrently” on two threads without
+ordering. A late keepalive after `ttl_ms: 0` would re-arm the WSJT-X station
+hold timeout and look like a stuck hold.
+
+### 3.7 Agent inputs
+
+| Input | Notes |
+|-------|--------|
+| USB-serial **CTS** (or other pin) | KEY → interface → CTS; event-driven if possible |
+| GPIO / other | Agent-specific |
+| Manual / test | Grave/backtick **`** KEY — `inhibit-test` / `tools/send_inhibit_hold.py --interactive` |
+
+Debounce and **hang** (anti-chatter) live in the agent. The WSJT-X station applies only
+**hold timeout** (safety) so a **deadman** cannot leave a hold stuck forever.
+
+### 3.8 Targets
+
+```text
+host:port   e.g.  192.168.1.40:22372
+```
+
+Unicast UDP is enough for small multi-op. Each WSJT-X station parses independently.
+Multiple agents → same WSJT-X station: **one** hold timeout (last valid hold wins; any valid
+release clears).
+
+---
+
+## 4. UDP protocol (WSJT-X station ↔ agent)
+
+**Transport:** UDP, UTF-8 JSON, max **512** bytes.  
+**Port:** **22372** (WSJT-X station listens; agent sends).
+
+| Field | Type | Required | Meaning |
+|-------|------|----------|---------|
+| `tx_inhibit` | int | yes | Protocol id; must be **1** |
+| `ttl_ms` | int | yes | **hold_timeout_ms**: hold lifetime from receipt, or **0** = **release hold**. Non-zero: 100…30000. Not agent hang. |
+| `station` | string | recommended | Badge (`held by …`) |
+| `band` | string | optional | Informational (not filtered today) |
+| `seq` | number | optional | Informational |
+
+### Hold (and keepalive — same shape)
+
+```json
+{"tx_inhibit":1,"ttl_ms":600,"station":"ROY-222-SSB","band":"222","seq":1}
+```
+
+Re-arms the WSJT-X station **hold timeout** to `now + ttl_ms` (last packet wins).
+Keepalives are the same shape; they refresh the hold timeout while KEY is asserted
+or agent hang is still running.
+
+### Release hold (normal end)
+
+```json
+{"tx_inhibit":1,"ttl_ms":0,"station":"ROY-222-SSB","band":"222","seq":2}
+```
+
+Sent when agent hang finishes after **release KEY** (or on operator quit).
+**This is how a healthy agent ends the hold.** Do not rely on WSJT-X station timeout as
+the normal path.
+
+### Hold timeout (WSJT-X station) and deadman
+
+If no hold packet arrives before the **hold timeout**, the WSJT-X station ends the hold
+anyway. That is the **hold timeout** path for a **deadman** (hang not managed)
+or other silence — not the preferred end of a normal transmission.
+
+### Invalid packets
+
+Malformed JSON, wrong `tx_inhibit`, bad `ttl_ms`, oversized: **ignored**.
+
+### 4.1 Trust model — read this before exposing the port
+
+**There is no authentication.** The station binds `0.0.0.0:22372` and accepts a hold
+from any host that can reach it. That is deliberate for a small trusted multi-op LAN,
+where the alternative (keys, pairing, config) buys nothing against the actual threat.
+
+**What an attacker can do:** stop you transmitting. Sustained suppression needs
+sustained packets — a single hold lasts at most `ttl_ms` (30 s ceiling, ~600 ms in
+practice), so the effect decays as soon as the packets stop.
+
+**What an attacker cannot do: make you transmit.** The protocol has no packet that
+causes emission. Every message either starts, refreshes, or ends a *suppression*. The
+worst outcome is a station that will not key — inconvenient, and safe in the direction
+that matters for an unattended transmitter.
+
+**Operator guidance:**
+
+| Situation | Do |
+|---|---|
+| Agent on the same PC | Nothing. Loopback is not reachable from outside. |
+| Agent on your LAN | Allow UDP 22372 inbound on the **private** profile only. |
+| Station reachable from the internet | **Firewall the port.** Do not forward 22372. |
+| Shared or untrusted network | Treat "someone can stop my TX" as a real possibility. |
+
+**Not addressed today:** a sender allowlist, and per-station addressing (any valid hold
+holds every station that receives it). Both are straightforward to add if a deployment
+needs them; neither is implemented, so do not assume either.
+
+---
+
+## 5. Local CTS KEY — not in this build
+
+**Decision:** no CTS in the WSJT-X station binary. **UDP hold only** + RTS/DTR PTT.
+
+**Why:** floating/driven CTS caused intermittent false hold. Worse than
+requiring a KEY agent (or the `inhibit-test` helper) on UDP.
+
+Until CTS is opt-in and safe: KEY agent → UDP, or localhost helper.
+
+---
+
+## 6. Testing locally
+
+Enable TX Inhibit, RTS/DTR on a real serial port, then send the same UDP a KEY
+agent would (default **127.0.0.1:22372**). Expect red **TX INHIBITED**; WSJT-X station
+does not **assert PTT** while hold is active.
+
+### `inhibit-test` / `inhibit-test-gui` (KEY-agent stand-ins)
+
+| Binary | Platform | Notes |
+|--------|----------|--------|
+| **`inhibit-test`** | Linux / Windows console | Canonical CLI (Qt). |
+| **`inhibit-test-gui`** | Windows GUI | Native Win32; mouse or grave; same protocol. |
+
+Implements §3 (Hold sender + KEYing monitor):
+
+| Action | Effect |
+|--------|--------|
+| **` (grave) down** (or GUI button) | **assert KEY** → hold (`ttl_ms`=hold_timeout) + keepalives |
+| **` up** / button up | KEY open → hang per §3.2, then **release hold** (`ttl_ms: 0`) after hang |
+| **`~` (shift+grave)** | **Latch on** — hold stays asserted after key release, so the keyboard is free to drive WSJT-X. Reads as continuous KEY (hang 0). Press `` ` `` or `~` again to clear; `` ` `` always clears the latch. |
+| **q** / **Esc** / Force RELEASE | cancel keepalives, **release hold** (quit on console) |
+
+**KEY key is grave/backtick `` ` ``** (left of `1` on US keyboards) — **not Space**.
+Unshifted `` ` `` is momentary; **`~` (shifted) latches** the hold on until either key
+is pressed again.
+
+Hang policy (default): break-in **1.5× word gap** from measured dit; continuous
+KEY (long mark ≥500 ms) **hang = 0**. Override: `--fixed-hang-ms` (console) or
+**fixed hang ms** field (GUI).
+
+```text
+inhibit-test --host 127.0.0.1 --port 22372 --station TEST-KEY --ttl-ms 600
+inhibit-test --fixed-hang-ms 0
+bin\inhibit-test-gui.exe
+```
+
+If the WSJT-X station bound an ephemeral port, pass that `--port`.
+
+**Input focus:** console default = this terminal only (`--global-keys` = system-wide).
+GUI = keys only while the GUI window is focused. **Linux console:** group
+`input` required for `/dev/input`; without it **`inhibit-test` refuses to start**.
+
+**Digi RF checks:** hold `` ` `` ≥500 ms (continuous, hang 0) or fixed hang 0.
+
+### Python: `tools/send_inhibit_hold.py`
+
+```bash
+python3 tools/send_inhibit_hold.py --interactive
+python3 tools/send_inhibit_hold.py --ttl-ms 3000 --station TEST
+python3 tools/send_inhibit_hold.py --ttl-ms 0
+```
+
+Operator checklist: [INSTALL.md §6](../INSTALL.md#6-test-tx-inhibit-with-the-key-helper-inhibit-test).
+
+---
+
+## 7. Code map
+
+| Piece | Location |
+|-------|----------|
+| Parse, hold timeout, badge, counters (pure) | `TxInhibit/TxInhibitLogic.hpp` |
+| UDP listen, hold timeout, want_tx mix | `TxInhibit/TxInhibitGate.{hpp,cpp}` (no serial) |
+| Pin filter: `do_ptt` → want_tx → assert PTT / release PTT | `Transceiver/HamlibTransceiver.cpp` |
+| Settings **Enable TX Inhibit** + signals | `Configuration.{hpp,cpp,ui}` |
+| Status badge + `InhibitStatus` | `widgets/mainwindow.cpp` |
+| MessageClient type 17 | `Network/NetworkMessage.hpp`, `MessageClient` |
+| KEY-agent stand-in | **`inhibit-test`** (`tools/inhibit-test/`); Windows **`inhibit-test-gui`** (`tools/inhibit_spacebar/`); `send_inhibit_hold.py` |
+
+**Maintainer notes (algorithm)**
+
+- Hamlib alone owns serial/CAT and may **assert PTT** / **release PTT** (RTS/DTR).
+  TxInhibit never opens a second serial handle.
+- With TX Inhibit active, software PTT state follows **want_tx**, not the pin
+  reading (poll must not treat “**release PTT** while hold” as “not want_tx”).
+- Normal hold end is **release hold** (`ttl_ms: 0`) after agent hang.
+  Fail-open: a **deadman** still ends via the WSJT-X station **hold timeout**.
+- Agent **hang** is not implemented in the WSJT-X station; WSJT-X station only has **hold timeout**.
+- UDP bind failure is logged and non-fatal; stock PTT continues.
+- Identifier names in code may still say gate/hold/block/intent; align in a
+  later code pass. This document is the language target.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,17 @@ add_executable (test_emulate_split_transceiver test_emulate_split_transceiver.cp
 target_link_libraries (test_emulate_split_transceiver Boost::log wsjt_qt Qt5::Test Qt5::Network Qt5::Widgets)
 add_test (test_emulate_split_transceiver test_emulate_split_transceiver)
 
+add_executable (test_tx_inhibit_logic test_tx_inhibit_logic.cpp)
+target_link_libraries (test_tx_inhibit_logic wsjt_qt Qt5::Test Qt5::Network)
+add_test (test_tx_inhibit_logic test_tx_inhibit_logic)
+
+# Logger.cpp is compiled into the wsjtx app, not wsjt_qt, but archive
+# members this test drags in (Configuration -> FileDownload on MinGW)
+# reference the sys/data global loggers it defines.
+add_executable (test_tx_inhibit_gate test_tx_inhibit_gate.cpp ${CMAKE_SOURCE_DIR}/Logger.cpp)
+target_link_libraries (test_tx_inhibit_gate wsjt_qt Boost::log_setup Qt5::Test Qt5::Network)
+add_test (test_tx_inhibit_gate test_tx_inhibit_gate)
+
 add_executable (test_bwf_file test_bwf_file.cpp)
 target_link_libraries (test_bwf_file wsjt_qt wsjt_qtmm Qt5::Test Qt5::Multimedia)
 add_test (test_bwf_file test_bwf_file)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,13 @@ add_executable (test_tx_inhibit_logic test_tx_inhibit_logic.cpp)
 target_link_libraries (test_tx_inhibit_logic wsjt_qt Qt5::Test Qt5::Network)
 add_test (test_tx_inhibit_logic test_tx_inhibit_logic)
 
+add_executable (test_keying_monitor
+  ${CMAKE_SOURCE_DIR}/tools/inhibit-agent/test_keying_monitor.cpp)
+target_include_directories (test_keying_monitor PRIVATE
+  ${CMAKE_SOURCE_DIR}/tools/inhibit-agent)
+target_link_libraries (test_keying_monitor Qt5::Core)
+add_test (test_keying_monitor test_keying_monitor)
+
 # Logger.cpp is compiled into the wsjtx app, not wsjt_qt, but archive
 # members this test drags in (Configuration -> FileDownload on MinGW)
 # reference the sys/data global loggers it defines.

--- a/tests/test_tx_inhibit_gate.cpp
+++ b/tests/test_tx_inhibit_gate.cpp
@@ -1,0 +1,199 @@
+// Integration tests for TxInhibitGate: the intent/hold interaction and the
+// gate lifecycle, over a real UDP socket and a real event loop.
+//
+// test_tx_inhibit_logic covers GateLogic, which is pure and takes injected
+// time. Nothing covered the part a rebase is most likely to break: the wiring
+// between do_ptt's intent, the UDP hold, and the physicalPtt emission that
+// drives the radio. That code lives in upstream-owned files
+// (HamlibTransceiver, Configuration), so it is the most exposed to upstream
+// churn -- and a break there is silent until someone with a radio notices.
+//
+// See docs/REVIEW-rc2.md H6.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QtTest>
+
+#include <QHostAddress>
+#include <QSignalSpy>
+#include <QUdpSocket>
+
+#include "TxInhibit/TxInhibitGate.hpp"
+#include "TxInhibit/TxInhibitLogic.hpp"
+
+namespace
+{
+  QByteArray hold_packet (int ttl_ms, char const * station = "TEST")
+  {
+    return QByteArray {"{\"tx_inhibit\":1,\"ttl_ms\":"}
+      + QByteArray::number (ttl_ms)
+      + ",\"station\":\"" + station + "\"}";
+  }
+}
+
+class TestTxInhibitGate final
+  : public QObject
+{
+  Q_OBJECT
+
+private slots:
+
+  // The core equation, end to end: assert PTT <=> want_tx and not hold.
+  // Crucially, want_tx never changes here -- only the hold does. That is the
+  // whole point of the feature, and the thing a careless refactor breaks.
+  void pinFollowsHoldWhileIntentStaysOn ()
+  {
+    TxInhibitGate gate;
+    QSignalSpy pin {&gate, &TxInhibitGate::physicalPtt};
+    QSignalSpy bound {&gate, &TxInhibitGate::portBound};
+
+    gate.start_listening ();
+    QCOMPARE (bound.count (), 1);
+    auto const port = bound.at (0).at (0).value<quint16> ();
+    QVERIFY2 (port != 0, "gate did not bind any UDP port");
+
+    // want_tx on, no hold -> assert
+    gate.set_intent (true);
+    QCOMPARE (pin.count (), 1);
+    QCOMPARE (pin.at (0).at (0).toBool (), true);
+
+    // hold arrives; want_tx is untouched -> release
+    QUdpSocket agent;
+    agent.writeDatagram (hold_packet (5000), QHostAddress::LocalHost, port);
+    QTRY_COMPARE (pin.count (), 2);
+    QCOMPARE (pin.at (1).at (0).toBool (), false);
+
+    // explicit release; want_tx still on -> assert again
+    agent.writeDatagram (hold_packet (0), QHostAddress::LocalHost, port);
+    QTRY_COMPARE (pin.count (), 3);
+    QCOMPARE (pin.at (2).at (0).toBool (), true);
+
+    gate.shutdown (false);
+  }
+
+  // Deadman: an agent that dies without releasing must not hold PTT off
+  // forever. The station's own hold timeout has to clear it.
+  void holdTimeoutRecoversWithoutRelease ()
+  {
+    TxInhibitGate gate;
+    QSignalSpy bound {&gate, &TxInhibitGate::portBound};
+    gate.start_listening ();
+    auto const port = bound.at (0).at (0).value<quint16> ();
+
+    gate.set_intent (true);
+    QSignalSpy pin {&gate, &TxInhibitGate::physicalPtt};
+
+    QUdpSocket agent;
+    agent.writeDatagram (hold_packet (TxInhibit::hold_timeout_ms_min),
+                         QHostAddress::LocalHost, port);
+    QTRY_COMPARE (pin.count (), 1);
+    QCOMPARE (pin.at (0).at (0).toBool (), false);   // held
+
+    // No release sent. The hold must expire on its own.
+    QTRY_COMPARE (pin.count (), 2);
+    QCOMPARE (pin.at (1).at (0).toBool (), true);    // recovered
+
+    gate.shutdown (false);
+  }
+
+  // A hold with no transmit intent must not assert PTT when it clears.
+  void releaseWithoutIntentDoesNotKey ()
+  {
+    TxInhibitGate gate;
+    QSignalSpy bound {&gate, &TxInhibitGate::portBound};
+    gate.start_listening ();
+    auto const port = bound.at (0).at (0).value<quint16> ();
+
+    QSignalSpy pin {&gate, &TxInhibitGate::physicalPtt};
+    QUdpSocket agent;
+    agent.writeDatagram (hold_packet (200), QHostAddress::LocalHost, port);
+    QTest::qWait (400);                      // hold applied and expired
+    agent.writeDatagram (hold_packet (0), QHostAddress::LocalHost, port);
+    QTest::qWait (100);
+
+    QCOMPARE (pin.count (), 0);              // never keyed: want_tx was false
+    gate.shutdown (false);
+  }
+
+  // Badge text and counters reach the GUI, and only on a real change.
+  void reportsStateChangesOnce ()
+  {
+    TxInhibitGate gate;
+    QSignalSpy bound {&gate, &TxInhibitGate::portBound};
+    gate.start_listening ();
+    auto const port = bound.at (0).at (0).value<quint16> ();
+
+    QSignalSpy changed {&gate, &TxInhibitGate::inhibitChanged};
+    QUdpSocket agent;
+    agent.writeDatagram (hold_packet (5000, "W1AW"), QHostAddress::LocalHost, port);
+    QTRY_VERIFY (changed.count () >= 1);
+    QCOMPARE (changed.at (0).at (0).toBool (), true);
+    QVERIFY (changed.at (0).at (1).toString ().contains (QStringLiteral ("W1AW")));
+
+    // A keepalive refreshes the timeout but is not a state change.
+    int const before = changed.count ();
+    agent.writeDatagram (hold_packet (5000, "W1AW"), QHostAddress::LocalHost, port);
+    QTest::qWait (100);
+    QCOMPARE (changed.count (), before);
+
+    gate.shutdown (false);
+  }
+
+  // shutdown(false) must not request a pin change: Hamlib may already be
+  // closed, and rig_set_ptt then fails. This is the teardown ordering that
+  // HamlibTransceiver::stop_tx_inhibit_gate depends on.
+  void shutdownWithoutPinEmitIsSilent ()
+  {
+    TxInhibitGate gate;
+    gate.start_listening ();
+    gate.set_intent (true);
+
+    QSignalSpy pin {&gate, &TxInhibitGate::physicalPtt};
+    gate.shutdown (false);
+    QCOMPARE (pin.count (), 0);
+
+    // And nothing may be emitted after shutdown, whatever arrives.
+    gate.set_intent (true);
+    QTest::qWait (60);
+    QCOMPARE (pin.count (), 0);
+  }
+
+  // Hold expiry must be measured on a monotonic base, so that a system-clock
+  // step cannot extend or curtail a hold. WSJT-X hosts step their clocks
+  // routinely (Meinberg, Dimension4, BktTimeSync). We cannot move the system
+  // clock from a test, so assert the property that makes the gate immune:
+  // its time base advances with elapsed time and is independent of the wall
+  // clock's absolute value.
+  void holdTimingUsesMonotonicBase ()
+  {
+    TxInhibitGate gate;
+    QSignalSpy bound {&gate, &TxInhibitGate::portBound};
+    gate.start_listening ();
+    auto const port = bound.at (0).at (0).value<quint16> ();
+    gate.set_intent (true);
+
+    QSignalSpy pin {&gate, &TxInhibitGate::physicalPtt};
+    QUdpSocket agent;
+
+    QElapsedTimer measured;
+    measured.start ();
+    agent.writeDatagram (hold_packet (300), QHostAddress::LocalHost, port);
+    QTRY_COMPARE (pin.count (), 1);          // held
+    QTRY_COMPARE (pin.count (), 2);          // expired
+    auto const elapsed = measured.elapsed ();
+
+    // Generous bounds: this asserts "the timeout tracks elapsed time", not a
+    // precise duration. A wall-clock base would still pass here on a quiet
+    // machine -- the real protection is that now_ms() uses QElapsedTimer, and
+    // this test fails loudly if that timing is ever wired to something that
+    // does not advance.
+    QVERIFY2 (elapsed >= 250 && elapsed < 3000,
+              qPrintable (QStringLiteral ("hold lasted %1 ms, expected ~300")
+                          .arg (elapsed)));
+
+    gate.shutdown (false);
+  }
+};
+
+QTEST_GUILESS_MAIN (TestTxInhibitGate)
+#include "test_tx_inhibit_gate.moc"

--- a/tests/test_tx_inhibit_logic.cpp
+++ b/tests/test_tx_inhibit_logic.cpp
@@ -1,0 +1,133 @@
+#include <QtTest>
+
+#include "TxInhibit/TxInhibitLogic.hpp"
+
+class TestTxInhibitLogic : public QObject
+{
+  Q_OBJECT
+
+private slots:
+  void radiateIsIntentAndNotHold ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 1000000;
+    QVERIFY (g.radiate (true, t));
+    QVERIFY (!g.radiate (false, t));
+
+    // Hold for 500 ms
+    QByteArray hold = R"({"tx_inhibit":1,"ttl_ms":500,"station":"TEST","seq":1})";
+    QVERIFY (g.on_datagram (hold, t));
+    QVERIFY (g.line_inhibited (t));
+    QVERIFY (!g.radiate (true, t));
+    QVERIFY (!g.radiate (false, t));
+
+    // After hold timeout: free again
+    QVERIFY (!g.line_inhibited (t + 501));
+    QVERIFY (g.radiate (true, t + 501));
+    QCOMPARE (g.expiries (), 1u);
+  }
+
+  void releaseClearsHold ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 2000000;
+    QByteArray hold = R"({"tx_inhibit":1,"ttl_ms":1000,"station":"KEY","seq":2})";
+    QVERIFY (g.on_datagram (hold, t));
+    QVERIFY (!g.radiate (true, t));
+
+    QByteArray rel = R"({"tx_inhibit":1,"ttl_ms":0,"station":"KEY","seq":3})";
+    QVERIFY (g.on_datagram (rel, t + 10));
+    QVERIFY (g.radiate (true, t + 10));
+    QCOMPARE (g.hold_rx (), 1u);
+    QCOMPARE (g.release_rx (), 1u);
+  }
+
+  void invalidProtocolVersionIgnored ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 3000000;
+    QByteArray bad = R"({"tx_inhibit":2,"ttl_ms":500,"station":"X"})";
+    QVERIFY (!g.on_datagram (bad, t));
+    QVERIFY (g.radiate (true, t));
+    QCOMPARE (g.invalid (), 1u);
+  }
+
+  void missingTtlIgnored ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 4000000;
+    QByteArray bad = R"({"tx_inhibit":1,"station":"X"})";
+    QVERIFY (!g.on_datagram (bad, t));
+    QVERIFY (g.radiate (true, t));
+    QCOMPARE (g.invalid (), 1u);
+  }
+
+  void outOfRangeTtlIgnored ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 5000000;
+    // Below min (100)
+    QVERIFY (!g.on_datagram (R"({"tx_inhibit":1,"ttl_ms":50})", t));
+    // Above max (30000)
+    QVERIFY (!g.on_datagram (R"({"tx_inhibit":1,"ttl_ms":30001})", t));
+    QVERIFY (g.radiate (true, t));
+    QCOMPARE (g.invalid (), 2u);
+  }
+
+  void oversizedDatagramIgnored ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 6000000;
+    QByteArray big (TxInhibit::max_datagram_bytes + 1, 'x');
+    QVERIFY (!g.on_datagram (big, t));
+    QCOMPARE (g.invalid (), 1u);
+  }
+
+  void keepaliveDoesNotFlipLevel ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 7000000;
+    QByteArray hold = R"({"tx_inhibit":1,"ttl_ms":500,"station":"A","seq":1})";
+    QVERIFY (g.on_datagram (hold, t));          // free → held
+    QByteArray keep = R"({"tx_inhibit":1,"ttl_ms":500,"station":"A","seq":2})";
+    QVERIFY (!g.on_datagram (keep, t + 100));   // still held
+    QVERIFY (g.line_inhibited (t + 100));
+    QCOMPARE (g.hold_rx (), 2u);
+  }
+
+  void redundantReleaseNoFlip ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 8000000;
+    QByteArray rel = R"({"tx_inhibit":1,"ttl_ms":0})";
+    QVERIFY (!g.on_datagram (rel, t)); // already free
+    QVERIFY (g.radiate (true, t));
+    QCOMPARE (g.release_rx (), 1u);
+  }
+
+  void badgeTextWithAndWithoutStation ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 9000000;
+    QCOMPARE (g.badge_text (t), QString {});
+
+    QVERIFY (g.on_datagram (R"({"tx_inhibit":1,"ttl_ms":500})", t));
+    QCOMPARE (g.badge_text (t), QStringLiteral ("TX INHIBITED"));
+
+    // Keepalive / refresh may not flip hold level (returns false) but updates station.
+    (void) g.on_datagram (R"({"tx_inhibit":1,"ttl_ms":500,"station":"W1AW"})", t + 1);
+    QCOMPARE (g.badge_text (t + 1), QStringLiteral ("TX INHIBITED — held by W1AW"));
+  }
+
+  void stringTtlAccepted ()
+  {
+    TxInhibit::GateLogic g;
+    qint64 t = 10000000;
+    // Interop: ttl_ms as string digits
+    QVERIFY (g.on_datagram (R"({"tx_inhibit":1,"ttl_ms":"400","station":"S"})", t));
+    QVERIFY (g.line_inhibited (t));
+  }
+};
+
+QTEST_MAIN (TestTxInhibitLogic)
+#include "test_tx_inhibit_logic.moc"

--- a/tools/inhibit-agent/99-keyline-not-modem.rules
+++ b/tools/inhibit-agent/99-keyline-not-modem.rules
@@ -1,0 +1,9 @@
+# Keep ModemManager from opening the Keyline (or a WA1HCO FT230X) and
+# asserting RTS, which keys the radio with no WSJT-X / WIMS running.
+#
+#   sudo cp tools/inhibit-agent/99-keyline-not-modem.rules /etc/udev/rules.d/
+#   sudo udevadm control --reload-rules && sudo udevadm trigger
+
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", ENV{ID_MM_DEVICE_IGNORE}="1"
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{manufacturer}=="WA1HCO", ENV{ID_MM_DEVICE_IGNORE}="1"
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{product}=="*Keyline*", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/tools/inhibit-agent/CMakeLists.txt
+++ b/tools/inhibit-agent/CMakeLists.txt
@@ -1,0 +1,45 @@
+# inhibit-agent — production KEY (CTS) -> localhost/LAN TX Inhibit hold.
+# CLI for scripting; GUI for operators. Linux and Windows.
+
+set (INHIBIT_AGENT_CORE
+  agent.cpp
+  agent.hpp
+  keying_monitor.hpp
+  )
+
+add_executable (inhibit-agent
+  main_cli.cpp
+  ${INHIBIT_AGENT_CORE}
+  )
+target_include_directories (inhibit-agent PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}
+  )
+target_link_libraries (inhibit-agent Qt5::Core Qt5::Network Qt5::SerialPort)
+if (WIN32)
+  set_target_properties (inhibit-agent PROPERTIES WIN32_EXECUTABLE OFF)
+endif ()
+set_target_properties (inhibit-agent PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+add_executable (inhibit-agent-gui
+  main_gui.cpp
+  ${INHIBIT_AGENT_CORE}
+  )
+target_include_directories (inhibit-agent-gui PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}
+  )
+target_link_libraries (inhibit-agent-gui Qt5::Widgets Qt5::Network Qt5::SerialPort)
+if (WIN32)
+  set_target_properties (inhibit-agent-gui PROPERTIES WIN32_EXECUTABLE ON)
+endif ()
+set_target_properties (inhibit-agent-gui PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+install (TARGETS inhibit-agent inhibit-agent-gui
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
+  BUNDLE DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
+  )

--- a/tools/inhibit-agent/agent.cpp
+++ b/tools/inhibit-agent/agent.cpp
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "agent.hpp"
+
+#include <QDateTime>
+#include <QFile>
+#include <QHostInfo>
+#include <QSerialPortInfo>
+
+#include <algorithm>
+
+namespace {
+
+QByteArray encode_hold (QString const& station, QString const& band,
+                        qint64 seq, int ttl_ms)
+{
+  QByteArray body;
+  body += "{\"tx_inhibit\":1,\"ttl_ms\":";
+  body += QByteArray::number (ttl_ms);
+  body += ",\"station\":\"";
+  body += station.toUtf8 ();
+  body += "\",\"band\":\"";
+  body += band.toUtf8 ();
+  body += "\",\"seq\":";
+  body += QByteArray::number (seq);
+  body += '}';
+  return body;
+}
+
+bool looks_like_keyline (QSerialPortInfo const& info)
+{
+  QString blob = (info.manufacturer () + QLatin1Char (' ')
+                  + info.description () + QLatin1Char (' ')
+                  + info.serialNumber ()).toUpper ();
+  return blob.contains (QLatin1String ("WA1HCO"))
+    || blob.contains (QLatin1String ("KEYLINE"));
+}
+
+bool looks_like_builtin_com (QSerialPortInfo const& info)
+{
+  QString n = info.portName ();
+#if defined (Q_OS_WIN)
+  return n.compare (QLatin1String ("COM1"), Qt::CaseInsensitive) == 0;
+#else
+  return n.startsWith (QLatin1String ("ttyS"));
+#endif
+}
+
+} // namespace
+
+InhibitAgent::InhibitAgent (Config const& cfg, QObject * parent)
+  : QObject (parent)
+  , cfg_ (cfg)
+{
+  poll_.setInterval (5);
+  keepalive_.setInterval (std::max (50, cfg_.keepalive_ms));
+  connect (&poll_, &QTimer::timeout, this, &InhibitAgent::on_poll);
+  connect (&keepalive_, &QTimer::timeout, this, &InhibitAgent::on_keepalive);
+}
+
+QString InhibitAgent::state_name (AgentState s)
+{
+  switch (s)
+    {
+    case AgentState::Open: return QStringLiteral ("OPEN");
+    case AgentState::Inhibiting: return QStringLiteral ("INHIBITING");
+    case AgentState::Hang: return QStringLiteral ("HANG");
+    case AgentState::SenseFault: return QStringLiteral ("SENSE FAULT");
+    }
+  return QStringLiteral ("UNKNOWN");
+}
+
+QString InhibitAgent::dest_text () const
+{
+  return cfg_.dest_host + QLatin1Char (':')
+    + QString::number (cfg_.dest_port);
+}
+
+bool InhibitAgent::parse_dest_addr (QString const& addr, QString * host,
+                                    quint16 * port, QString * err)
+{
+  int const c = addr.lastIndexOf (QLatin1Char (':'));
+  if (c <= 0 || c == addr.size () - 1)
+    {
+      if (err)
+        {
+          *err = QStringLiteral ("addr must be host:port (got %1)").arg (addr);
+        }
+      return false;
+    }
+  bool ok = false;
+  uint p = addr.mid (c + 1).toUInt (&ok);
+  if (!ok || p < 1 || p > 65535)
+    {
+      if (err)
+        {
+          *err = QStringLiteral ("addr port must be 1..65535");
+        }
+      return false;
+    }
+  if (host)
+    {
+      *host = addr.left (c);
+    }
+  if (port)
+    {
+      *port = static_cast<quint16> (p);
+    }
+  return true;
+}
+
+QString InhibitAgent::auto_detect_serial_port (QString * note)
+{
+  QList<QSerialPortInfo> ports = QSerialPortInfo::availablePorts ();
+  QStringList keyline;
+  QStringList usb;
+  for (QSerialPortInfo const& p : ports)
+    {
+      if (looks_like_keyline (p))
+        {
+          keyline << p.portName ();
+        }
+      else if (!looks_like_builtin_com (p))
+        {
+          usb << p.portName ();
+        }
+    }
+  if (keyline.size () == 1)
+    {
+      if (note)
+        {
+          *note = QStringLiteral ("auto-selected Keyline %1").arg (keyline[0]);
+        }
+      return keyline[0];
+    }
+  if (keyline.size () > 1)
+    {
+      if (note)
+        {
+          *note = QStringLiteral (
+              "multiple Keyline ports (%1); pass --port")
+              .arg (keyline.join (QLatin1String (", ")));
+        }
+      return {};
+    }
+  if (usb.size () == 1)
+    {
+      if (note)
+        {
+          *note = QStringLiteral ("auto-selected serial %1").arg (usb[0]);
+        }
+      return usb[0];
+    }
+  if (note)
+    {
+      if (ports.isEmpty ())
+        {
+          *note = QStringLiteral ("no serial ports found");
+        }
+      else
+        {
+          *note = QStringLiteral (
+              "could not auto-pick a KEY serial port (%1); pass --port")
+              .arg (list_serial_ports ().simplified ());
+        }
+    }
+  return {};
+}
+
+QString InhibitAgent::list_serial_ports ()
+{
+  QStringList lines;
+  int skipped_builtin = 0;
+  for (QSerialPortInfo const& p : QSerialPortInfo::availablePorts ())
+    {
+      if (looks_like_builtin_com (p)
+          && p.manufacturer ().isEmpty () && p.description ().isEmpty ())
+        {
+          ++skipped_builtin;
+          continue;
+        }
+      QString tag;
+      if (looks_like_keyline (p))
+        {
+          tag = QStringLiteral (" [Keyline]");
+        }
+      lines << QStringLiteral ("%1  %2 %3%4")
+                   .arg (p.portName (), -12)
+                   .arg (p.manufacturer ())
+                   .arg (p.description ())
+                   .arg (tag);
+    }
+  if (lines.isEmpty ())
+    {
+      return skipped_builtin
+        ? QStringLiteral ("(no USB-serial ports; %1 builtin COM/ttyS skipped)")
+              .arg (skipped_builtin)
+        : QStringLiteral ("(no serial ports)");
+    }
+  if (skipped_builtin)
+    {
+      lines << QStringLiteral ("(%1 builtin COM/ttyS omitted)").arg (skipped_builtin);
+    }
+  return lines.join (QLatin1Char ('\n'));
+}
+
+bool InhibitAgent::start ()
+{
+  fault_.clear ();
+  dest_addr_ = QHostAddress (cfg_.dest_host);
+  if (dest_addr_.isNull ())
+    {
+      QHostInfo info = QHostInfo::fromName (cfg_.dest_host);
+      if (info.addresses ().isEmpty ())
+        {
+          enter_fault (QStringLiteral ("cannot resolve %1").arg (cfg_.dest_host));
+          return false;
+        }
+      dest_addr_ = info.addresses ().first ();
+    }
+
+  if (cfg_.serial_port.isEmpty ())
+    {
+      enter_fault (QStringLiteral ("no serial port"));
+      return false;
+    }
+
+  serial_.setPortName (cfg_.serial_port);
+  // Open so modem-status (CTS) is readable. Do not assert RTS/DTR —
+  // Keyline J3 is an inhibit/PTT output driven by RTS.
+  if (!serial_.open (QIODevice::ReadWrite))
+    {
+      enter_fault (QStringLiteral ("open %1 failed: %2")
+                   .arg (cfg_.serial_port, serial_.errorString ()));
+      return false;
+    }
+  serial_.setDataTerminalReady (false);
+  serial_.setRequestToSend (false);
+  try_set_usb_latency ();
+
+  keying_.reset_transmission ();
+  key_down_ = false;
+  hold_active_ = false;
+  hang_until_ms_ = -1;
+  keepalive_.stop ();
+  poll_.start ();
+  set_state (AgentState::Open, QStringLiteral ("CTS on %1 -> %2")
+             .arg (cfg_.serial_port, dest_text ()));
+  return true;
+}
+
+void InhibitAgent::stop ()
+{
+  poll_.stop ();
+  if (hold_active_)
+    {
+      end_hold ("stop");
+    }
+  if (serial_.isOpen ())
+    {
+      serial_.close ();
+    }
+}
+
+void InhibitAgent::try_set_usb_latency ()
+{
+#if defined (Q_OS_LINUX)
+  QString name = cfg_.serial_port;
+  if (name.startsWith (QLatin1String ("/dev/")))
+    {
+      name = name.section (QLatin1Char ('/'), -1);
+    }
+  QStringList paths {
+    QStringLiteral ("/sys/class/tty/%1/device/latency_timer").arg (name),
+    QStringLiteral ("/sys/bus/usb-serial/devices/%1/latency_timer").arg (name),
+  };
+  for (QString const& path : paths)
+    {
+      QFile f (path);
+      if (f.open (QIODevice::WriteOnly | QIODevice::Truncate))
+        {
+          f.write ("1");
+          return;
+        }
+    }
+#else
+  (void) 0;
+#endif
+}
+
+void InhibitAgent::set_state (AgentState s, QString const& detail)
+{
+  bool changed = (s != state_);
+  state_ = s;
+  if (s != AgentState::SenseFault)
+    {
+      fault_.clear ();
+    }
+  if (changed)
+    {
+      emit stateChanged (s, detail);
+    }
+}
+
+void InhibitAgent::enter_fault (QString const& reason)
+{
+  fault_ = reason;
+  poll_.stop ();
+  if (hold_active_)
+    {
+      end_hold ("sense fault");
+    }
+  if (serial_.isOpen ())
+    {
+      serial_.close ();
+    }
+  set_state (AgentState::SenseFault, reason);
+  emit logLine (QStringLiteral ("SENSE FAULT  %1").arg (reason));
+}
+
+bool InhibitAgent::read_key (bool * keyed)
+{
+  if (!serial_.isOpen ())
+    {
+      return false;
+    }
+  QSerialPort::PinoutSignals pins = serial_.pinoutSignals ();
+  if (serial_.error () != QSerialPort::NoError
+      && serial_.error () != QSerialPort::TimeoutError)
+    {
+      return false;
+    }
+  bool cts = (pins & QSerialPort::ClearToSendSignal) != 0;
+  *keyed = cfg_.invert ? !cts : cts;
+  return true;
+}
+
+void InhibitAgent::on_poll ()
+{
+  qint64 now = QDateTime::currentMSecsSinceEpoch ();
+  bool keyed = false;
+  if (!read_key (&keyed))
+    {
+      enter_fault (serial_.isOpen ()
+                   ? QStringLiteral ("CTS read failed on %1: %2")
+                       .arg (cfg_.serial_port, serial_.errorString ())
+                   : QStringLiteral ("serial port closed"));
+      return;
+    }
+  if (keyed != key_down_)
+    {
+      on_key_edge (keyed, now);
+    }
+  if (hang_until_ms_ >= 0 && now >= hang_until_ms_)
+    {
+      hang_until_ms_ = -1;
+      end_hold ("hang done");
+    }
+}
+
+void InhibitAgent::on_key_edge (bool keyed, qint64 now_ms)
+{
+  key_down_ = keyed;
+  if (keyed)
+    {
+      hang_until_ms_ = -1;
+      keying_.on_key_assert (now_ms);
+      start_hold ();
+      set_state (AgentState::Inhibiting, QStringLiteral ("KEY assert"));
+      emit logLine (QStringLiteral ("KEY assert"));
+      return;
+    }
+  int hang_ms = keying_.on_key_open (now_ms);
+  emit logLine (QStringLiteral ("KEY open  class=%1  hang_ms=%2")
+                .arg (QString::fromLatin1 (keying_.class_name ()))
+                .arg (hang_ms));
+  if (hang_ms <= 0)
+    {
+      hang_until_ms_ = -1;
+      end_hold ("KEY open");
+      return;
+    }
+  hang_until_ms_ = now_ms + hang_ms;
+  set_state (AgentState::Hang,
+             QStringLiteral ("hang %1 ms (%2)").arg (hang_ms)
+             .arg (QString::fromLatin1 (keying_.class_name ())));
+}
+
+void InhibitAgent::start_hold ()
+{
+  if (hold_active_)
+    {
+      return;
+    }
+  hold_active_ = true;
+  send_packet (cfg_.hold_timeout_ms, false, nullptr);
+  keepalive_.start ();
+}
+
+void InhibitAgent::end_hold (char const * reason)
+{
+  hang_until_ms_ = -1;
+  if (!hold_active_)
+    {
+      if (state_ != AgentState::SenseFault)
+        {
+          set_state (AgentState::Open, QString::fromLatin1 (reason ? reason : ""));
+        }
+      return;
+    }
+  hold_active_ = false;
+  keepalive_.stop ();
+  send_packet (0, false, reason);
+  if (state_ != AgentState::SenseFault)
+    {
+      set_state (AgentState::Open, QString::fromLatin1 (reason ? reason : "release"));
+    }
+}
+
+void InhibitAgent::on_keepalive ()
+{
+  if (hold_active_)
+    {
+      send_packet (cfg_.hold_timeout_ms, true, nullptr);
+    }
+}
+
+void InhibitAgent::send_packet (int ttl_ms, bool is_keepalive,
+                               char const * release_reason)
+{
+  if (is_keepalive && !hold_active_)
+    {
+      return;
+    }
+  QByteArray payload = encode_hold (cfg_.station, cfg_.band, seq_++, ttl_ms);
+  qint64 n = sock_.writeDatagram (payload, dest_addr_, cfg_.dest_port);
+  if (ttl_ms == 0)
+    {
+      ++releases_sent_;
+    }
+  else if (is_keepalive)
+    {
+      ++keepalives_sent_;
+    }
+  else
+    {
+      ++holds_sent_;
+    }
+  QString tag = ttl_ms == 0
+    ? QStringLiteral ("RELEASE")
+    : (is_keepalive ? QStringLiteral ("KEEPALIVE") : QStringLiteral ("HOLD"));
+  QString line = QStringLiteral ("%1  ttl_ms=%2  -> %3  (holds=%4 ka=%5 rel=%6)")
+                   .arg (tag)
+                   .arg (ttl_ms)
+                   .arg (dest_text ())
+                   .arg (holds_sent_)
+                   .arg (keepalives_sent_)
+                   .arg (releases_sent_);
+  if (ttl_ms == 0 && release_reason && release_reason[0])
+    {
+      line += QStringLiteral ("  (%1)").arg (QString::fromLatin1 (release_reason));
+    }
+  if (!is_keepalive)
+    {
+      emit logLine (line);
+    }
+  if (n < 0)
+    {
+      emit logLine (QStringLiteral ("send failed: %1").arg (sock_.errorString ()));
+    }
+}

--- a/tools/inhibit-agent/agent.cpp
+++ b/tools/inhibit-agent/agent.cpp
@@ -9,6 +9,13 @@
 
 #include <algorithm>
 
+#if defined (Q_OS_WIN)
+# include <windows.h>
+#else
+# include <sys/ioctl.h>
+# include <termios.h>
+#endif
+
 namespace {
 
 QByteArray encode_hold (QString const& station, QString const& band,
@@ -226,21 +233,27 @@ bool InhibitAgent::start ()
     }
 
   serial_.setPortName (cfg_.serial_port);
+  serial_.setFlowControl (QSerialPort::NoFlowControl);
+#if QT_VERSION < QT_VERSION_CHECK (5, 10, 0)
+  // Qt < 5.10 restores termios on close (RTS/DTR back to driver default).
+  serial_.setSettingsRestoredOnClose (false);
+#endif
   // Open so modem-status (CTS) is readable. Do not assert RTS/DTR —
-  // Keyline J3 is an inhibit/PTT output driven by RTS.
+  // Keyline J3 is an inhibit/PTT output driven by RTS. QSerialPort and
+  // the USB-serial driver assert both on open; force them idle at once.
   if (!serial_.open (QIODevice::ReadWrite))
     {
       enter_fault (QStringLiteral ("open %1 failed: %2")
                    .arg (cfg_.serial_port, serial_.errorString ()));
       return false;
     }
-  serial_.setDataTerminalReady (false);
-  serial_.setRequestToSend (false);
+  force_outputs_idle ();
   try_set_usb_latency ();
 
   keying_.reset_transmission ();
   key_down_ = false;
   hold_active_ = false;
+  warned_rts_ = false;
   hang_until_ms_ = -1;
   keepalive_.stop ();
   poll_.start ();
@@ -258,8 +271,41 @@ void InhibitAgent::stop ()
     }
   if (serial_.isOpen ())
     {
+      force_outputs_idle ();
       serial_.close ();
     }
+}
+
+void InhibitAgent::force_outputs_idle ()
+{
+  if (!serial_.isOpen ())
+    {
+      return;
+    }
+  serial_.setFlowControl (QSerialPort::NoFlowControl);
+  serial_.setDataTerminalReady (false);
+  serial_.setRequestToSend (false);
+#if defined (Q_OS_WIN)
+  HANDLE h = reinterpret_cast<HANDLE> (serial_.handle ());
+  if (h && h != INVALID_HANDLE_VALUE)
+    {
+      EscapeCommFunction (h, CLRRTS);
+      EscapeCommFunction (h, CLRDTR);
+    }
+#else
+  int fd = static_cast<int> (serial_.handle ());
+  if (fd >= 0)
+    {
+      int bits = TIOCM_RTS | TIOCM_DTR;
+      ioctl (fd, TIOCMBIC, &bits);
+      struct termios tio;
+      if (tcgetattr (fd, &tio) == 0)
+        {
+          tio.c_cflag &= ~static_cast<tcflag_t> (HUPCL);
+          tcsetattr (fd, TCSANOW, &tio);
+        }
+    }
+#endif
 }
 
 void InhibitAgent::try_set_usb_latency ()
@@ -312,6 +358,7 @@ void InhibitAgent::enter_fault (QString const& reason)
     }
   if (serial_.isOpen ())
     {
+      force_outputs_idle ();
       serial_.close ();
     }
   set_state (AgentState::SenseFault, reason);
@@ -329,6 +376,16 @@ bool InhibitAgent::read_key (bool * keyed)
       && serial_.error () != QSerialPort::TimeoutError)
     {
       return false;
+    }
+  if (pins & QSerialPort::RequestToSendSignal)
+    {
+      force_outputs_idle ();
+      if (!warned_rts_)
+        {
+          warned_rts_ = true;
+          emit logLine (QStringLiteral (
+              "RTS was asserted — forced idle (Keyline J3 must not key)"));
+        }
     }
   bool cts = (pins & QSerialPort::ClearToSendSignal) != 0;
   *keyed = cfg_.invert ? !cts : cts;

--- a/tools/inhibit-agent/agent.hpp
+++ b/tools/inhibit-agent/agent.hpp
@@ -1,0 +1,95 @@
+// inhibit-agent core — CTS sense + hold sender + KEYing monitor.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef INHIBIT_AGENT_AGENT_HPP_
+#define INHIBIT_AGENT_AGENT_HPP_
+
+#include "keying_monitor.hpp"
+
+#include <QByteArray>
+#include <QHostAddress>
+#include <QObject>
+#include <QSerialPort>
+#include <QString>
+#include <QTimer>
+#include <QUdpSocket>
+
+enum class AgentState
+{
+  Open,
+  Inhibiting,
+  Hang,
+  SenseFault
+};
+
+class InhibitAgent : public QObject
+{
+  Q_OBJECT
+public:
+  struct Config
+  {
+    QString serial_port;
+    QString dest_host {QStringLiteral ("127.0.0.1")};
+    quint16 dest_port {22372};
+    bool invert {false};
+    int hold_timeout_ms {600};
+    int keepalive_ms {200};
+    QString station {QStringLiteral ("inhibit-agent")};
+    QString band {QStringLiteral ("local")};
+  };
+
+  explicit InhibitAgent (Config const& cfg, QObject * parent = nullptr);
+
+  bool start ();
+  void stop ();
+
+  AgentState state () const { return state_; }
+  QString fault_reason () const { return fault_; }
+  QString serial_port () const { return cfg_.serial_port; }
+  QString dest_text () const;
+  Config const& config () const { return cfg_; }
+
+  static QString state_name (AgentState s);
+  static bool parse_dest_addr (QString const& addr, QString * host,
+                               quint16 * port, QString * err);
+  static QString auto_detect_serial_port (QString * note);
+  static QString list_serial_ports ();
+
+signals:
+  void stateChanged (AgentState state, QString detail);
+  void logLine (QString line);
+
+private slots:
+  void on_poll ();
+  void on_keepalive ();
+
+private:
+  void set_state (AgentState s, QString const& detail);
+  void enter_fault (QString const& reason);
+  bool read_key (bool * keyed);
+  void on_key_edge (bool keyed, qint64 now_ms);
+  void start_hold ();
+  void end_hold (char const * reason);
+  void send_packet (int ttl_ms, bool is_keepalive, char const * release_reason);
+  void try_set_usb_latency ();
+
+  Config cfg_;
+  QHostAddress dest_addr_;
+  QSerialPort serial_;
+  QUdpSocket sock_;
+  QTimer poll_;
+  QTimer keepalive_;
+  KeyingMonitor keying_;
+  AgentState state_ {AgentState::SenseFault};
+  QString fault_;
+  bool key_down_ {false};
+  bool hold_active_ {false};
+  qint64 hang_until_ms_ {-1};
+  qint64 seq_ {1};
+  int holds_sent_ {0};
+  int keepalives_sent_ {0};
+  int releases_sent_ {0};
+};
+
+#endif

--- a/tools/inhibit-agent/agent.hpp
+++ b/tools/inhibit-agent/agent.hpp
@@ -73,6 +73,9 @@ private:
   void end_hold (char const * reason);
   void send_packet (int ttl_ms, bool is_keepalive, char const * release_reason);
   void try_set_usb_latency ();
+  // Keyline J3 is RTS. USB-serial open/close defaults assert RTS and
+  // key the radio. Force RTS+DTR idle and leave them idle on close.
+  void force_outputs_idle ();
 
   Config cfg_;
   QHostAddress dest_addr_;
@@ -90,6 +93,7 @@ private:
   int holds_sent_ {0};
   int keepalives_sent_ {0};
   int releases_sent_ {0};
+  bool warned_rts_ {false};
 };
 
 #endif

--- a/tools/inhibit-agent/keying_monitor.hpp
+++ b/tools/inhibit-agent/keying_monitor.hpp
@@ -1,0 +1,173 @@
+// KEYing monitor — same hang policy as inhibit-test (docs/TX_INHIBIT.md §3).
+// Break-in CW: hang = 1.5 × word gap (10.5 × dit), clamp 315–1260 ms.
+// Continuous KEY (SSB / non-break-in): hang = 0. No software PTT debounce.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef INHIBIT_AGENT_KEYING_MONITOR_HPP_
+#define INHIBIT_AGENT_KEYING_MONITOR_HPP_
+
+#include <QtGlobal>
+
+#include <algorithm>
+#include <cmath>
+
+enum class KeyClass
+{
+  Unknown,
+  BreakInCw,
+  Continuous
+};
+
+class KeyingMonitor
+{
+public:
+  static int const kHangMinMs = 315;          // ~40 WPM
+  static int const kHangMaxMs = 1260;         // ~10 WPM
+  static int const kContinuousMarkMs = 500;
+  static double constexpr kHangWordGapMult = 1.5;
+  static int const kWordGapDits = 7;
+  static double constexpr kMaxIntraTxGapDits = 5.0;
+
+  void reset_transmission ()
+  {
+    key_class_ = KeyClass::Unknown;
+    dit_ms_ = 0.0;
+    mark_open_ = false;
+    mark_start_ms_ = -1;
+    gap_start_ms_ = -1;
+  }
+
+  void on_key_assert (qint64 now_ms)
+  {
+    if (gap_start_ms_ >= 0)
+      {
+        int gap = static_cast<int> (now_ms - gap_start_ms_);
+        on_gap_closed (gap);
+        gap_start_ms_ = -1;
+      }
+    mark_open_ = true;
+    mark_start_ms_ = now_ms;
+  }
+
+  // KEY open — hang_ms to wait before EOT (0 = release now).
+  int on_key_open (qint64 now_ms)
+  {
+    int mark_ms = 0;
+    if (mark_open_ && mark_start_ms_ >= 0)
+      {
+        mark_ms = static_cast<int> (now_ms - mark_start_ms_);
+        note_mark (mark_ms);
+      }
+    mark_open_ = false;
+    mark_start_ms_ = -1;
+    gap_start_ms_ = now_ms;
+
+    if (key_class_ == KeyClass::Continuous
+        || (key_class_ == KeyClass::Unknown && mark_ms >= kContinuousMarkMs))
+      {
+        key_class_ = KeyClass::Continuous;
+        return 0;
+      }
+    if (key_class_ == KeyClass::BreakInCw || dit_ms_ > 0.0)
+      {
+        key_class_ = KeyClass::BreakInCw;
+        return hang_ms_break_in ();
+      }
+    if (mark_ms > 0 && mark_ms < kContinuousMarkMs)
+      {
+        note_dit_sample (static_cast<double> (mark_ms));
+        return hang_ms_break_in ();
+      }
+    return 0;
+  }
+
+  KeyClass key_class () const { return key_class_; }
+  double dit_ms () const { return dit_ms_; }
+
+  int hang_ms_break_in () const
+  {
+    if (dit_ms_ <= 0.0)
+      {
+        return kHangMinMs;
+      }
+    double hang = kHangWordGapMult * static_cast<double> (kWordGapDits) * dit_ms_;
+    int h = static_cast<int> (std::lround (hang));
+    return std::max (kHangMinMs, std::min (kHangMaxMs, h));
+  }
+
+  char const * class_name () const
+  {
+    switch (key_class_)
+      {
+      case KeyClass::BreakInCw: return "break-in CW";
+      case KeyClass::Continuous: return "continuous (non-break-in/SSB)";
+      default: return "unknown";
+      }
+  }
+
+private:
+  void note_mark (int mark_ms)
+  {
+    if (mark_ms <= 0)
+      {
+        return;
+      }
+    if (mark_ms >= kContinuousMarkMs && key_class_ != KeyClass::BreakInCw)
+      {
+        key_class_ = KeyClass::Continuous;
+        return;
+      }
+    if (dit_ms_ <= 0.0)
+      {
+        if (mark_ms < kContinuousMarkMs)
+          {
+            note_dit_sample (static_cast<double> (mark_ms));
+          }
+        return;
+      }
+    if (mark_ms < 2.0 * dit_ms_)
+      {
+        note_dit_sample (static_cast<double> (mark_ms));
+      }
+  }
+
+  void note_dit_sample (double sample_ms)
+  {
+    if (sample_ms <= 0.0)
+      {
+        return;
+      }
+    if (dit_ms_ <= 0.0)
+      {
+        dit_ms_ = sample_ms;
+      }
+    else
+      {
+        dit_ms_ = 0.35 * sample_ms + 0.65 * dit_ms_;
+      }
+  }
+
+  void on_gap_closed (int gap_ms)
+  {
+    if (gap_ms <= 0)
+      {
+        return;
+      }
+    double max_gap = (dit_ms_ > 0.0)
+      ? kMaxIntraTxGapDits * dit_ms_
+      : static_cast<double> (kContinuousMarkMs);
+    if (gap_ms <= max_gap)
+      {
+        key_class_ = KeyClass::BreakInCw;
+      }
+  }
+
+  KeyClass key_class_ {KeyClass::Unknown};
+  double dit_ms_ {0.0};
+  bool mark_open_ {false};
+  qint64 mark_start_ms_ {-1};
+  qint64 gap_start_ms_ {-1};
+};
+
+#endif

--- a/tools/inhibit-agent/main_cli.cpp
+++ b/tools/inhibit-agent/main_cli.cpp
@@ -1,0 +1,197 @@
+// inhibit-agent — CLI (scripting). Requires serial port + dest addr.
+//
+//   inhibit-agent --port /dev/ttyUSB0 --addr 127.0.0.1:22372
+//   inhibit-agent COM7 192.168.1.40:22372
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "agent.hpp"
+
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QTextStream>
+
+#include <csignal>
+
+#if defined (Q_OS_WIN)
+# include <windows.h>
+#endif
+
+namespace {
+
+QCoreApplication * g_app = nullptr;
+
+void request_quit (int)
+{
+  if (g_app)
+    {
+      QCoreApplication::quit ();
+    }
+}
+
+#if defined (Q_OS_WIN)
+BOOL WINAPI console_ctrl (DWORD)
+{
+  request_quit (0);
+  return TRUE;
+}
+#endif
+
+} // namespace
+
+int main (int argc, char * argv[])
+{
+  QCoreApplication app (argc, argv);
+  g_app = &app;
+  QCoreApplication::setApplicationName (QStringLiteral ("inhibit-agent"));
+  QCoreApplication::setApplicationVersion (QStringLiteral ("1.0"));
+
+  QCommandLineParser parser;
+  parser.setApplicationDescription (
+      QStringLiteral (
+          "SSB/CW KEY (USB-serial CTS) -> TX Inhibit hold.\n"
+          "CLI: pass the serial port and dest host:port.\n"
+          "Same hang policy as inhibit-test (CW hang; SSB hang 0)."));
+  parser.addHelpOption ();
+  parser.addVersionOption ();
+  parser.addPositionalArgument (
+      QStringLiteral ("port"),
+      QStringLiteral ("USB-serial device (COM7 or /dev/ttyUSB0)"),
+      QStringLiteral ("[port]"));
+  parser.addPositionalArgument (
+      QStringLiteral ("addr"),
+      QStringLiteral ("Gate address host:port"),
+      QStringLiteral ("[addr]"));
+  QCommandLineOption portOpt {
+    QStringList () << "p" << "port",
+    QStringLiteral ("USB-serial device (CTS = KEY)"),
+    QStringLiteral ("device")};
+  QCommandLineOption addrOpt {
+    QStringList () << "a" << "addr",
+    QStringLiteral ("WSJT-X gate address (host:port)"),
+    QStringLiteral ("host:port")};
+  QCommandLineOption invertOpt {
+    QStringList () << "invert",
+    QStringLiteral ("Invert CTS polarity")};
+  QCommandLineOption listOpt {
+    QStringList () << "list-ports",
+    QStringLiteral ("List serial ports and exit")};
+  QCommandLineOption ttlOpt {
+    QStringList () << "t" << "ttl-ms",
+    QStringLiteral ("hold_timeout_ms on hold/keepalive (default 600)"),
+    QStringLiteral ("ms"),
+    QStringLiteral ("600")};
+  parser.addOption (portOpt);
+  parser.addOption (addrOpt);
+  parser.addOption (invertOpt);
+  parser.addOption (listOpt);
+  parser.addOption (ttlOpt);
+  parser.process (app);
+
+  QTextStream out (stdout);
+  QTextStream err (stderr);
+
+  if (parser.isSet (listOpt))
+    {
+      out << InhibitAgent::list_serial_ports () << '\n';
+      return 0;
+    }
+
+  QStringList pos = parser.positionalArguments ();
+  QString port = parser.value (portOpt);
+  QString addr = parser.value (addrOpt);
+  if (port.isEmpty () && pos.size () >= 1)
+    {
+      port = pos[0];
+    }
+  if (addr.isEmpty () && pos.size () >= 2)
+    {
+      addr = pos[1];
+    }
+  else if (addr.isEmpty () && pos.size () == 1 && !parser.isSet (portOpt))
+    {
+      // Single positional after --port DEVICE is the addr.
+    }
+  if (addr.isEmpty () && pos.size () == 1 && parser.isSet (portOpt))
+    {
+      addr = pos[0];
+    }
+
+  if (port.isEmpty () || addr.isEmpty ())
+    {
+      err << "inhibit-agent: CLI requires a USB-serial port and dest addr.\n"
+          << "  inhibit-agent --port /dev/ttyUSB0 --addr 127.0.0.1:22372\n"
+          << "  inhibit-agent COM7 192.168.1.40:22372\n"
+          << "  inhibit-agent --list-ports\n"
+          << "GUI (no args): inhibit-agent-gui\n";
+      return 2;
+    }
+
+  QString host;
+  quint16 dest_port = 0;
+  QString perr;
+  if (!InhibitAgent::parse_dest_addr (addr, &host, &dest_port, &perr))
+    {
+      err << "inhibit-agent: " << perr << '\n';
+      return 2;
+    }
+
+  int ttl = parser.value (ttlOpt).toInt ();
+  if (ttl < 100 || ttl > 30000)
+    {
+      err << "ttl-ms must be 100..30000\n";
+      return 2;
+    }
+
+  InhibitAgent::Config cfg;
+  cfg.serial_port = port;
+  cfg.dest_host = host;
+  cfg.dest_port = dest_port;
+  cfg.invert = parser.isSet (invertOpt);
+  cfg.hold_timeout_ms = ttl;
+
+  InhibitAgent agent (cfg);
+  QObject::connect (&agent, &InhibitAgent::stateChanged, &app,
+                    [&] (AgentState s, QString detail) {
+                      out << QDateTime::currentDateTime ().toString (
+                          QStringLiteral ("hh:mm:ss.zzz"))
+                          << "  STATE " << InhibitAgent::state_name (s);
+                      if (!detail.isEmpty ())
+                        {
+                          out << "  " << detail;
+                        }
+                      out << '\n';
+                      out.flush ();
+                    });
+  QObject::connect (&agent, &InhibitAgent::logLine, &app,
+                    [&] (QString line) {
+                      out << QDateTime::currentDateTime ().toString (
+                          QStringLiteral ("hh:mm:ss.zzz"))
+                          << "  " << line << '\n';
+                      out.flush ();
+                    });
+
+  if (!agent.start ())
+    {
+      err << "inhibit-agent: " << agent.fault_reason () << '\n';
+      return 1;
+    }
+
+  std::signal (SIGINT, request_quit);
+  std::signal (SIGTERM, request_quit);
+#if defined (Q_OS_WIN)
+  SetConsoleCtrlHandler (console_ctrl, TRUE);
+#endif
+
+  QObject::connect (&app, &QCoreApplication::aboutToQuit, &agent,
+                    [&] () { agent.stop (); });
+
+  out << "inhibit-agent  port=" << cfg.serial_port
+      << "  addr=" << agent.dest_text ()
+      << (cfg.invert ? "  invert" : "")
+      << "\n  CTS asserted = KEY.  Ctrl-C releases and quits.\n";
+  out.flush ();
+  return app.exec ();
+}

--- a/tools/inhibit-agent/main_gui.cpp
+++ b/tools/inhibit-agent/main_gui.cpp
@@ -1,0 +1,236 @@
+// inhibit-agent-gui — CTS KEY in, dest host:port out.
+// Gate address is editable (default 127.0.0.1:22372). Serial KEY is
+// auto-picked (Keyline / only USB-serial) unless --port is given.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "agent.hpp"
+
+#include <QApplication>
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QDateTime>
+#include <QFont>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QWidget>
+
+namespace {
+
+QString state_stylesheet (AgentState s)
+{
+  switch (s)
+    {
+    case AgentState::Open:
+      return QStringLiteral (
+          "QLabel { background: #d8f0d8; color: #145214; border: 2px solid #2a7a2a; }");
+    case AgentState::Inhibiting:
+      return QStringLiteral (
+          "QLabel { background: #f5c4c4; color: #7a1010; border: 2px solid #a01818; }");
+    case AgentState::Hang:
+      return QStringLiteral (
+          "QLabel { background: #ffe4b8; color: #7a4a00; border: 2px solid #c07800; }");
+    case AgentState::SenseFault:
+      return QStringLiteral (
+          "QLabel { background: #ffe566; color: #5a2000; border: 2px solid #c04000; }");
+    }
+  return {};
+}
+
+} // namespace
+
+int main (int argc, char * argv[])
+{
+  QApplication app (argc, argv);
+  QApplication::setApplicationName (QStringLiteral ("inhibit-agent"));
+  QApplication::setApplicationVersion (QStringLiteral ("1.0"));
+
+  QCommandLineParser parser;
+  parser.setApplicationDescription (
+      QStringLiteral (
+          "SSB/CW KEY (USB-serial CTS) -> TX Inhibit hold.\n"
+          "Set dest host:port in the window (default 127.0.0.1:22372)."));
+  parser.addHelpOption ();
+  parser.addVersionOption ();
+  QCommandLineOption portOpt {
+    QStringList () << "p" << "port",
+    QStringLiteral ("Override USB-serial device (CTS = KEY)"),
+    QStringLiteral ("device")};
+  QCommandLineOption addrOpt {
+    QStringList () << "a" << "addr",
+    QStringLiteral ("Initial gate address (host:port)"),
+    QStringLiteral ("host:port")};
+  QCommandLineOption invertOpt {
+    QStringList () << "invert",
+    QStringLiteral ("Invert CTS polarity")};
+  parser.addOption (portOpt);
+  parser.addOption (addrOpt);
+  parser.addOption (invertOpt);
+  parser.process (app);
+
+  InhibitAgent::Config cfg;
+  cfg.invert = parser.isSet (invertOpt);
+  QString pick_note;
+  if (parser.isSet (portOpt))
+    {
+      cfg.serial_port = parser.value (portOpt);
+      pick_note = QStringLiteral ("port from --port");
+    }
+  else
+    {
+      cfg.serial_port = InhibitAgent::auto_detect_serial_port (&pick_note);
+    }
+  if (parser.isSet (addrOpt))
+    {
+      QString err;
+      if (!InhibitAgent::parse_dest_addr (parser.value (addrOpt),
+                                          &cfg.dest_host, &cfg.dest_port, &err))
+        {
+          pick_note = err;
+        }
+    }
+
+  QWidget win;
+  win.setWindowTitle (QStringLiteral ("inhibit-agent"));
+  win.resize (560, 400);
+
+  auto * state = new QLabel (QStringLiteral ("STARTING"));
+  state->setAlignment (Qt::AlignCenter);
+  QFont sf = state->font ();
+  sf.setPointSize (28);
+  sf.setBold (true);
+  state->setFont (sf);
+  state->setMinimumHeight (88);
+  state->setStyleSheet (state_stylesheet (AgentState::Open));
+
+  auto * dest_edit = new QLineEdit (
+      cfg.dest_host + QLatin1Char (':') + QString::number (cfg.dest_port));
+  dest_edit->setPlaceholderText (QStringLiteral ("127.0.0.1:22372"));
+  dest_edit->setClearButtonEnabled (true);
+  auto * dest_apply = new QPushButton (QStringLiteral ("Apply"));
+  dest_apply->setToolTip (QStringLiteral ("Send holds to this WSJT-X gate"));
+
+  auto * dest_row = new QHBoxLayout;
+  dest_row->addWidget (new QLabel (QStringLiteral ("Gate")));
+  dest_row->addWidget (dest_edit, 1);
+  dest_row->addWidget (dest_apply);
+
+  auto * info = new QLabel;
+  QFont bf = info->font ();
+  bf.setPointSize (12);
+  info->setFont (bf);
+  info->setWordWrap (true);
+
+  auto * log = new QPlainTextEdit;
+  log->setReadOnly (true);
+  log->setMaximumBlockCount (200);
+  QFont lf = log->font ();
+  lf.setPointSize (11);
+  lf.setFamily (QStringLiteral ("monospace"));
+  log->setFont (lf);
+
+  auto * quit = new QPushButton (QStringLiteral ("Quit"));
+  quit->setMinimumHeight (32);
+
+  auto * layout = new QVBoxLayout (&win);
+  layout->addWidget (state);
+  layout->addLayout (dest_row);
+  layout->addWidget (info);
+  layout->addWidget (log, 1);
+  auto * row = new QHBoxLayout;
+  row->addStretch (1);
+  row->addWidget (quit);
+  layout->addLayout (row);
+
+  auto append_log = [log] (QString const& line) {
+    log->appendPlainText (
+        QDateTime::currentDateTime ().toString (QStringLiteral ("hh:mm:ss.zzz"))
+        + QLatin1Char (' ') + line);
+  };
+
+  InhibitAgent * agent = new InhibitAgent (cfg, &win);
+
+  auto refresh_info = [info, &agent, &pick_note] () {
+    info->setText (
+        QStringLiteral ("CTS KEY on %1\nGate %2\n%3")
+            .arg (agent->serial_port ().isEmpty ()
+                  ? QStringLiteral ("(none)")
+                  : agent->serial_port ())
+            .arg (agent->dest_text ())
+            .arg (pick_note));
+  };
+
+  auto hook_agent = [&] () {
+    QObject::connect (agent, &InhibitAgent::stateChanged, &win,
+                      [state] (AgentState s, QString detail) {
+                        QString t = InhibitAgent::state_name (s);
+                        if (!detail.isEmpty ())
+                          {
+                            t += QLatin1Char ('\n') + detail;
+                          }
+                        state->setText (t);
+                        state->setStyleSheet (state_stylesheet (s));
+                      });
+    QObject::connect (agent, &InhibitAgent::logLine, &win, append_log);
+  };
+  hook_agent ();
+
+  auto start_agent = [&] () {
+    refresh_info ();
+    if (cfg.serial_port.isEmpty ())
+      {
+        state->setText (QStringLiteral ("SENSE FAULT"));
+        state->setStyleSheet (state_stylesheet (AgentState::SenseFault));
+        append_log (pick_note.isEmpty ()
+                    ? QStringLiteral ("no KEY serial")
+                    : pick_note);
+        return;
+      }
+    if (!agent->start ())
+      {
+        state->setText (QStringLiteral ("SENSE FAULT"));
+        state->setStyleSheet (state_stylesheet (AgentState::SenseFault));
+        append_log (agent->fault_reason ());
+      }
+    else
+      {
+        append_log (pick_note.isEmpty ()
+                    ? QStringLiteral ("started")
+                    : pick_note);
+      }
+  };
+
+  auto apply_dest = [&] () {
+    QString err;
+    QString host;
+    quint16 port = 0;
+    if (!InhibitAgent::parse_dest_addr (dest_edit->text ().trimmed (),
+                                        &host, &port, &err))
+      {
+        append_log (err);
+        return;
+      }
+    cfg.dest_host = host;
+    cfg.dest_port = port;
+    pick_note = QStringLiteral ("gate %1").arg (dest_edit->text ().trimmed ());
+    agent->stop ();
+    delete agent;
+    agent = new InhibitAgent (cfg, &win);
+    hook_agent ();
+    start_agent ();
+  };
+
+  QObject::connect (dest_apply, &QPushButton::clicked, &win, apply_dest);
+  QObject::connect (dest_edit, &QLineEdit::returnPressed, &win, apply_dest);
+  QObject::connect (quit, &QPushButton::clicked, &app, &QCoreApplication::quit);
+  QObject::connect (&app, &QCoreApplication::aboutToQuit, &win,
+                    [&] () { agent->stop (); });
+
+  start_agent ();
+  win.show ();
+  return app.exec ();
+}

--- a/tools/inhibit-agent/test_keying_monitor.cpp
+++ b/tools/inhibit-agent/test_keying_monitor.cpp
@@ -1,0 +1,81 @@
+// Self-running hang-policy checks (no serial / no UDP).
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "keying_monitor.hpp"
+
+#include <cstdio>
+
+static int g_fails = 0;
+
+#define CHECK(cond) do { \
+  if (!(cond)) { \
+    std::fprintf (stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+    ++g_fails; \
+  } \
+} while (0)
+
+static void test_continuous_ssb_hang_zero ()
+{
+  KeyingMonitor m;
+  m.on_key_assert (0);
+  int hang = m.on_key_open (2000);   // 2 s PTT
+  CHECK (hang == 0);
+  CHECK (m.key_class () == KeyClass::Continuous);
+}
+
+static void test_mark_over_500_is_continuous ()
+{
+  KeyingMonitor m;
+  m.on_key_assert (0);
+  int hang = m.on_key_open (500);
+  CHECK (hang == 0);
+  CHECK (m.key_class () == KeyClass::Continuous);
+}
+
+static void test_breakin_short_mark_has_hang ()
+{
+  KeyingMonitor m;
+  m.on_key_assert (0);
+  int hang = m.on_key_open (60);     // 20 WPM dit
+  CHECK (hang >= KeyingMonitor::kHangMinMs);
+  CHECK (hang <= KeyingMonitor::kHangMaxMs);
+  CHECK (m.key_class () == KeyClass::BreakInCw || m.dit_ms () > 0.0);
+}
+
+static void test_breakin_rekey_during_hang ()
+{
+  KeyingMonitor m;
+  m.on_key_assert (0);
+  int hang = m.on_key_open (60);
+  CHECK (hang > 0);
+  m.on_key_assert (60 + 80);         // gap shorter than hang
+  hang = m.on_key_open (60 + 80 + 180);
+  CHECK (hang > 0);
+  CHECK (m.key_class () == KeyClass::BreakInCw);
+}
+
+static void test_hang_covers_word_gap_sizing ()
+{
+  KeyingMonitor m;
+  m.on_key_assert (0);
+  m.on_key_open (60);
+  int hang = m.hang_ms_break_in ();
+  // 1.5 × 7 × 60 = 630, inside 315..1260
+  CHECK (hang == 630);
+}
+
+int main ()
+{
+  test_continuous_ssb_hang_zero ();
+  test_mark_over_500_is_continuous ();
+  test_breakin_short_mark_has_hang ();
+  test_breakin_rekey_during_hang ();
+  test_hang_covers_word_gap_sizing ();
+  if (g_fails)
+    {
+      std::fprintf (stderr, "%d check(s) failed\n", g_fails);
+      return 1;
+    }
+  std::printf ("test_keying_monitor: 5/5 passed\n");
+  return 0;
+}

--- a/tools/send_inhibit_hold.py
+++ b/tools/send_inhibit_hold.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""KEY-agent stand-in: send TX Inhibit hold/release UDP datagrams to a gate.
+
+Protocol and KEY-agent design: docs/TX_INHIBIT.md
+
+Grave/backtick ` is KEY *level* (not Space). Windows: VK_OEM_3; Linux: KEY_GRAVE
+(/dev/input; may need group input).
+
+  python3 tools/send_inhibit_hold.py --interactive
+  python3 tools/send_inhibit_hold.py --ttl-ms 3000 --station TEST
+  python3 tools/send_inhibit_hold.py --ttl-ms 0
+
+Default UDP port is 22372.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import select
+import socket
+import sys
+import time
+
+DEFAULT_PORT = 22372
+DEFAULT_TTL_MS = 600  # hold_timeout_ms (safety), not hang
+KEEPALIVE_S = 0.2
+# Hang = 1.5 × word gap = 10.5 × dit (docs/TX_INHIBIT.md §3.4); WPM ~10..40
+HANG_MIN_S = 0.315
+HANG_MAX_S = 1.260
+HANG_DIT_MULT = 10.5
+CONTINUOUS_MARK_S = 0.5  # non-break-in / SSB → hang 0
+
+
+def encode(station: str, band: str, seq: int, ttl_ms: int) -> bytes:
+    return json.dumps(
+        {
+            "tx_inhibit": 1,
+            "ttl_ms": int(ttl_ms),
+            "station": station,
+            "band": band,
+            "seq": int(seq),
+        },
+        separators=(",", ":"),
+    ).encode()
+
+
+def send_to(sock: socket.socket, host: str, port: int, payload: bytes) -> None:
+    sock.sendto(payload, (host, port))
+
+
+def one_shot(args: argparse.Namespace) -> None:
+    msg = encode(args.station, args.band, args.seq, args.ttl_ms)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    send_to(sock, args.host, args.port, msg)
+    print(f"sent {msg!r} -> {args.host}:{args.port}")
+
+
+class HangPolicy:
+    def __init__(self) -> None:
+        self.dit_s = 0.0
+
+    def hang_s_for_closure(self, closure_s: float) -> float:
+        """Break-in: 1.5×word gap from dit estimate. Continuous KEY: 0."""
+        if closure_s <= 0:
+            return 0.0
+        if closure_s >= CONTINUOUS_MARK_S:
+            return 0.0  # non-break-in CW / SSB
+        if self.dit_s <= 0:
+            self.dit_s = closure_s
+        else:
+            self.dit_s = 0.35 * closure_s + 0.65 * self.dit_s
+        hang = HANG_DIT_MULT * self.dit_s
+        return max(HANG_MIN_S, min(HANG_MAX_S, hang))
+
+
+def _space_level_win() -> bool | None:
+    try:
+        import ctypes
+    except ImportError:
+        return None
+    VK_OEM_3 = 0xC0  # US keyboard `~ (grave)
+    return bool(ctypes.windll.user32.GetAsyncKeyState(VK_OEM_3) & 0x8000)
+
+
+def _quit_win() -> bool:
+    try:
+        import ctypes
+    except ImportError:
+        return False
+    user32 = ctypes.windll.user32
+    return bool(user32.GetAsyncKeyState(ord("Q")) & 0x8000) or bool(
+        user32.GetAsyncKeyState(0x1B) & 0x8000
+    )
+
+
+_evdev_fd = None
+
+
+def _open_evdev() -> bool:
+    global _evdev_fd
+    if _evdev_fd is not None:
+        return _evdev_fd >= 0
+    _evdev_fd = -1
+    import glob
+    import struct
+
+    candidates = sorted(glob.glob("/dev/input/by-path/*-event-kbd")) + sorted(
+        glob.glob("/dev/input/event*")
+    )
+    # EVIOCGKEY size: KEY_MAX is typically 767 → ~96 bytes; use 256
+    EVIOCGKEY = 0x80004518 | (256 << 16)  # rough; use fcntl with correct size below
+    for path in candidates:
+        try:
+            fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        except OSError:
+            continue
+        # EVIOCGBIT(0) check skipped for brevity; try EVIOCGKEY
+        buf = bytearray(128)
+        try:
+            import fcntl
+            # EVIOCGKEY(len) = _IOC(_IOC_READ, 'E', 0x18, len)
+            req = 0x80004518 | (len(buf) << 16)
+            fcntl.ioctl(fd, req, buf)
+        except OSError:
+            os.close(fd)
+            continue
+        _evdev_fd = fd
+        return True
+    return False
+
+
+def _space_level_linux() -> bool | None:
+    if not _open_evdev():
+        return None
+    import fcntl
+
+    # Drain
+    try:
+        while os.read(_evdev_fd, 64):
+            pass
+    except BlockingIOError:
+        pass
+    except OSError:
+        return None
+    buf = bytearray(128)
+    req = 0x80004518 | (len(buf) << 16)
+    try:
+        fcntl.ioctl(_evdev_fd, req, buf)
+    except OSError:
+        return None
+    # KEY_GRAVE = 41 (backtick / left quote)
+    bit = 41
+    return bool(buf[bit // 8] & (1 << (bit % 8)))
+
+
+def space_down() -> bool | None:
+    """True/False if level available; None if no platform reader."""
+    if sys.platform == "win32":
+        return _space_level_win()
+    if sys.platform.startswith("linux"):
+        return _space_level_linux()
+    return None
+
+
+def interactive(args: argparse.Namespace) -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    seq = args.seq
+    hang = HangPolicy()
+    key_down = False
+    band_held = False
+    key_down_at = 0.0
+    hang_until = -1.0
+    fixed_hang = args.fixed_hang_ms
+    use_fixed = fixed_hang is not None
+
+    def emit(ttl_ms: int) -> None:
+        nonlocal seq
+        payload = encode(args.station, args.band, seq, ttl_ms)
+        send_to(sock, args.host, args.port, payload)
+        seq += 1
+        action = "HOLD" if ttl_ms else "RELEASE"
+        print(
+            f"{time.strftime('%H:%M:%S')}  {action}  ttl_ms={ttl_ms}  "
+            f"-> {args.host}:{args.port}",
+            flush=True,
+        )
+
+    level = space_down()
+    if level is None:
+        print(
+            "No KEY (grave/`) level reader on this platform (need Windows or Linux "
+            "/dev/input). Use the built inhibit-test binary, or fix input access.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(
+        f"Interactive KEY (level) → {args.host}:{args.port}\n"
+        f"  grave/`  = KEY level (press = hold, release = hang then free)\n"
+        f"  (not Space — typing won't false-trigger)\n"
+        f"  Ctrl-C    = quit\n"
+        f"  station={args.station!r}  ttl_ms={args.ttl_ms}  "
+        f"hang={'fixed '+str(fixed_hang)+'ms' if use_fixed else 'adaptive'}\n",
+        flush=True,
+    )
+
+    try:
+        while True:
+            now = time.monotonic()
+            space = bool(space_down())
+
+            if space and not key_down:
+                key_down = True
+                key_down_at = now
+                hang_until = -1.0
+                if not band_held:
+                    band_held = True
+                    emit(args.ttl_ms)
+                print(f"{now:10.3f}  KEY DOWN", flush=True)
+
+            if not space and key_down:
+                key_down = False
+                closure = now - key_down_at
+                if use_fixed:
+                    hang_s = max(0.0, (fixed_hang or 0) / 1000.0)
+                else:
+                    hang_s = hang.hang_s_for_closure(closure)
+                hang_until = now + hang_s
+                dit = f"  dit≈{hang.dit_s*1000:.0f} ms" if hang.dit_s > 0 else ""
+                print(
+                    f"{now:10.3f}  KEY UP    closure={closure*1000:.0f} ms  "
+                    f"hang={hang_s*1000:.0f} ms{dit}",
+                    flush=True,
+                )
+
+            if not key_down and hang_until >= 0 and now >= hang_until:
+                hang_until = -1.0
+                if band_held:
+                    emit(0)
+                    band_held = False
+                    print(f"{now:10.3f}  RELEASE (hang done)", flush=True)
+
+            if band_held and (now - getattr(interactive, "_last_ka", 0)) >= KEEPALIVE_S:
+                emit(args.ttl_ms)
+                interactive._last_ka = now  # type: ignore[attr-defined]
+
+            if band_held and not hasattr(interactive, "_last_ka"):
+                interactive._last_ka = now  # type: ignore[attr-defined]
+
+            time.sleep(0.01)
+    except KeyboardInterrupt:
+        if band_held:
+            emit(0)
+        print("\nquit (Ctrl-C)")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Send TX Inhibit hold/release UDP datagrams to wsjtx-inhibit"
+    )
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=DEFAULT_PORT)
+    p.add_argument(
+        "--ttl-ms",
+        type=int,
+        default=DEFAULT_TTL_MS,
+        help="Hold TTL ms; 0 = release (one-shot). Interactive: keepalive TTL.",
+    )
+    p.add_argument("--station", default="TEST-SSB")
+    p.add_argument("--band", default="144")
+    p.add_argument("--seq", type=int, default=1)
+    p.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Grave/` KEY level + hang (docs §3)",
+    )
+    p.add_argument(
+        "--fixed-hang-ms",
+        type=int,
+        default=None,
+        help="Interactive: fixed hang after KEY up instead of adaptive",
+    )
+    args = p.parse_args()
+    if args.interactive:
+        interactive(args)
+    else:
+        one_shot(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/widgets/mainwindow.cpp
+++ b/widgets/mainwindow.cpp
@@ -61,6 +61,7 @@
 #include "helper_functions.h"
 #include "revision_utils.hpp"
 #include "qt_helpers.hpp"
+#include "TxInhibit/TxInhibitLogic.hpp" // default_gate_port for the inhibit badge
 #include "Network/NetworkAccessManager.hpp"
 #include "Audio/soundout.h"
 #include "Audio/soundin.h"
@@ -4360,6 +4361,74 @@ bool MainWindow::eventFilter (QObject * object, QEvent * event)
   return QObject::eventFilter(object, event);
 }
 
+// TX Inhibit has no status-bar widget of its own: the operator-visible signal
+// is tx_status_label turning red and reading INHIBITED (see guiUpdate), and a
+// second box merely disrupted the spacing of the whole line.
+//
+// Everything else lives here, costing no layout space:
+//   * the tooltip on tx_status_label always describes the current state,
+//     including the bound port and who is holding;
+//   * a one-shot status message warns when the operator has opted in but the
+//     station is NOT reachable — the fail-open/fail-silent hole in C4. It fires
+//     only on a change, so it cannot nag.
+void MainWindow::update_inhibit_status ()
+{
+  if (!m_config.enable_tx_inhibit ())
+    {
+      tx_status_label.setToolTip ({});
+      m_tx_inhibit_warned_port = 0;
+      m_tx_inhibit_warned = false;
+      return;
+    }
+
+  // Read the port from Configuration every time rather than caching it:
+  // close_rig() zeroes it without emitting, and a stale copy would describe a
+  // station as protected when nothing is listening.
+  auto const port = m_config.tx_inhibit_port ();
+
+  if (m_tx_inhibited)
+    {
+      tx_status_label.setToolTip (
+        m_tx_inhibit_holder.isEmpty ()
+        ? tr ("TX Inhibit: a KEY agent is holding PTT off (UDP port %1).").arg (port)
+        : tr ("TX Inhibit: held by %1 (UDP port %2).").arg (m_tx_inhibit_holder).arg (port));
+    }
+  else if (!port)
+    {
+      tx_status_label.setToolTip (
+        tr ("TX Inhibit is enabled but NOT listening: no UDP port is bound.\n"
+            "The rig may be closed, PTT method may not be RTS/DTR, or the bind failed.\n"
+            "This station is NOT protected."));
+    }
+  else if (TxInhibit::default_gate_port == port)
+    {
+      tx_status_label.setToolTip (
+        tr ("TX Inhibit: listening for KEY-agent holds on UDP port %1.").arg (port));
+    }
+  else
+    {
+      tx_status_label.setToolTip (
+        tr ("TX Inhibit: port %1 was busy, so an ephemeral port (%2) is in use.\n"
+            "A KEY agent aimed at %1 will NOT reach this station.")
+        .arg (TxInhibit::default_gate_port).arg (port));
+    }
+
+  // Unreachable == enabled but not bound to the well-known port. Warn once per
+  // transition rather than on every refresh.
+  bool const unreachable = !port || TxInhibit::default_gate_port != port;
+  if (unreachable && (!m_tx_inhibit_warned || m_tx_inhibit_warned_port != port))
+    {
+      showStatusMessage (port
+                         ? tr ("TX Inhibit: listening on %1, not %2 — a KEY agent aimed"
+                               " at %2 will not reach this station")
+                           .arg (port).arg (TxInhibit::default_gate_port)
+                         : tr ("TX Inhibit is enabled but no UDP port is bound —"
+                               " this station is NOT protected"));
+    }
+  m_tx_inhibit_warned = unreachable;
+  m_tx_inhibit_warned_port = port;
+}
+
 void MainWindow::createStatusBar()                           //createStatusBar
 {
   tx_status_label.setAlignment (Qt::AlignHCenter);
@@ -4367,6 +4436,26 @@ void MainWindow::createStatusBar()                           //createStatusBar
   tx_status_label.setStyleSheet ("QLabel{color: #000000; background-color: #00ff00}");
   tx_status_label.setFrameStyle (QFrame::Panel | QFrame::Sunken);
   statusBar()->addWidget (&tx_status_label);
+
+  connect (&m_config, &Configuration::tx_inhibit_changed, this,
+           [this] (bool inhibited, QString const& source
+                   , quint32 hold_rx, quint32 release_rx
+                   , quint32 expiries, quint32 invalid) {
+             m_tx_inhibited = inhibited;
+             m_tx_inhibit_holder = inhibited ? source : QString {};
+             update_inhibit_status ();
+             if (m_messageClient)
+               {
+                 m_messageClient->inhibit_status (
+                   m_config.tx_inhibit_port (), inhibited, source,
+                   hold_rx, release_rx, expiries, invalid);
+               }
+           });
+  connect (&m_config, &Configuration::tx_inhibit_port_changed, this,
+           [this] (quint16) {
+             update_inhibit_status ();
+           });
+  update_inhibit_status ();
 
   config_label.setAlignment (Qt::AlignHCenter);
   config_label.setMinimumSize (QSize {80, 18});
@@ -5156,7 +5245,7 @@ void MainWindow::on_actionKeyboard_shortcuts_triggered()
   <tr><td><b>Esc      </b></td><td>Stop Tx, abort QSO, clear next-call queue</td></tr>
   <tr><td><b>F1       </b></td><td>Online User's Guide (Alt: transmit Tx6)</td></tr>
   <tr><td><b>Shift+F1  </b></td><td>Copyright Notice</td></tr>
-  <tr><td><b>Ctrl+F1  </b></td><td>About WSJT-X</td></tr>
+  <tr><td><b>Ctrl+F1  </b></td><td>About wsjtx-inhibit</td></tr>
   <tr><td><b>F2       </b></td><td>Open settings window (Alt: transmit Tx2)</td></tr>
   <tr><td><b>F3       </b></td><td>Display keyboard shortcuts (Alt: transmit Tx3)</td></tr>
   <tr><td><b>F4       </b></td><td>Clear DX Call, DX Grid, Tx messages 1-4 (Alt: transmit Tx4)</td></tr>
@@ -8437,6 +8526,15 @@ void MainWindow::guiUpdate()
           tx_status_label.setText(t.trimmed());
         }
       }
+      // Transmit intent, but a KEY agent is holding PTT off. m_transmitting is
+      // set by the sequencer (not from the PTT line), so without this the label
+      // reads "Tx: <message>" in transmit-yellow while the radio is silent.
+      // Covers Tune too, which also runs through this branch.
+      // Last, so it overrides every style/text chosen above.
+      if (m_tx_inhibited) {
+        tx_status_label.setStyleSheet("QLabel{color: #ffffff; background-color: #cc0000; font-weight: bold}");
+        tx_status_label.setText (tr ("Inhibit"));
+      }
     } else if(m_monitoring) {
       if (!m_tx_watchdog) {
         tx_status_label.setStyleSheet("QLabel{color: #000000; background-color: #00ff00}");
@@ -8473,6 +8571,13 @@ void MainWindow::guiUpdate()
           t += QString {"   %1%"}.arg (npct, 2);
         }
         tx_status_label.setText (t);
+        // Receiving with a hold active: nothing is being prevented right now,
+        // so this is ambient status rather than an alarm. Staying in the green
+        // family keeps the escalation to red (transmit branch) as the signal.
+        if (m_tx_inhibited) {
+          tx_status_label.setStyleSheet("QLabel{color: #000000; background-color: #b3ffb3}");
+          tx_status_label.setText (tr ("Inhibit"));
+        }
       }
       transmitDisplay(false);
     } else if (!m_diskData && !m_tx_watchdog) {

--- a/widgets/mainwindow.h
+++ b/widgets/mainwindow.h
@@ -787,6 +787,12 @@ private:
 
   // labels in status bar
   QLabel tx_status_label;
+  // Latest TX Inhibit state, mirrored here so guiUpdate() can report the
+  // physical PTT state rather than the sequencer's intent. See docs/TX_INHIBIT.md.
+  bool m_tx_inhibited {false};
+  QString m_tx_inhibit_holder;     // station named in the current hold, if any
+  bool m_tx_inhibit_warned {false};      // "not reachable" already reported?
+  quint16 m_tx_inhibit_warned_port {0};  // port that warning referred to
   QLabel config_label;
   QLabel mode_label;
   QLabel last_tx_label;
@@ -983,6 +989,7 @@ private:
   void setDecodedTextFont (QFont const&);
   void writeSettings();
   void createStatusBar();
+  void update_inhibit_status ();
   void updateStatusBar();
   void genStdMsgs(QString rpt, bool unconditional = false);
   void genCQMsg();

--- a/widgets/mainwindow.ui
+++ b/widgets/mainwindow.ui
@@ -4968,7 +4968,7 @@ QPushButton[state=&quot;ok&quot;] {
   </action>
   <action name="actionAbout">
    <property name="text">
-    <string>About WSJT-X</string>
+    <string>About wsjtx-inhibit</string>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutRole</enum>

--- a/widgets/mainwindow.ui
+++ b/widgets/mainwindow.ui
@@ -4968,7 +4968,7 @@ QPushButton[state=&quot;ok&quot;] {
   </action>
   <action name="actionAbout">
    <property name="text">
-    <string>About wsjtx-inhibit</string>
+    <string>About WSJT-X</string>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutRole</enum>


### PR DESCRIPTION
## Motivation

WSJT-X and SSB/CW stations sharing a band — in our case the W2SZ VHF
contest group interleaving FT8 with SSB/CW — must keep only one
transmitter keyed at a time. We have found that WSJT-X can listen
through SSB/CW station activity. The next goal is FT8 working stations
while SSB/CW continues to operate with priority. An interlock needs to
hold off the radio's PTT key line within milliseconds whenever SSB/CW
transmits.

Halt Tx is the wrong tool: it aborts the QSO sequence. TX Inhibit only
filters whether to assert PTT. Sequencing and audio continue under a
hold, and PTT is released the moment the interlock clears.

## Design

Two pieces, both in this PR.

### 1. PTT gate (this program)

Opt-in and off by default — zero behavior change unless enabled in
Settings.

- `TxInhibit/TxInhibitLogic.hpp` — pure gate logic with injected time.
  Invariant: assert PTT iff (want_tx and not hold).
- `TxInhibit/TxInhibitGate.cpp` — binds the logic to an **ephemeral** UDP
  socket (port announced in `InhibitStatus` type 17). Holds arrive as
  `NetworkMessage::TxInhibit` (type 18) with a per-controller lease TTL;
  lost refresh fails safe when that lease expires. Hold is the OR of live
  leases.
- Transceiver `do_ptt` paths consult the gate before keying; rig
  backend exceptions are contained so a CAT hiccup cannot leave PTT
  stuck asserted.
- While a hold is active the status bar shows a red **INHIBIT** badge.

There is deliberately no remote control of TX — only inhibition of it.
`docs/TX_INHIBIT.md` documents the datagram format and trust model.

### 2. Standalone KEY agent (`inhibit-agent` / `inhibit-agent-gui`)

The gate is not useful by itself. Something has to see the priority
KEY and send the hold datagrams. WIMS already has that program
(`wims-key-agent`; destinations come from WIMS discovery). This PR
ships a standalone agent so a dual-radio seat works with only WSJT-X —
no WIMS required.

- USB-serial **CTS** is the KEY input. The operator supplies the port.
- Destination is the WSJT-X gate `host:port` from InhibitStatus / tooltip
  (ephemeral; no fixed default).
- Hang policy matches the design doc: break-in CW hangs 1.5 × word gap
  so WSJT-X PTT does not follow dits; SSB / continuous KEY releases
  immediately. No software PTT debounce — the sense path is for
  switches that already debounce.
- **CLI** (`inhibit-agent`) for scripts, SSH, and startup files:
  `inhibit-agent --port /dev/ttyUSB0 --addr 127.0.0.1:<port-from-type-17>`
- **GUI** (`inhibit-agent-gui`) for operators: dest `host:port` must be
  Applied before KEY is armed (**NEED GATE** until then); CTS port is
  auto-picked (Keyline / WA1HCO USB strings, else the only non-builtin
  USB-serial) or `--port`.
- Fail-safe: process exit or a missing dongle stops keepalives; the
  gate deadman (~600 ms) opens. Wrong or missing COM is SENSE FAULT,
  never silent protection.

`docs/INHIBIT_AGENT.md` is the agent design. Wire format is the same
as any other KEY agent. Qt SerialPort is already a WSJT-X dependency.

## Testing

- `tests/test_tx_inhibit_logic.cpp` — QtTest suite for the pure logic.
- `tests/test_tx_inhibit_gate.cpp` — integration suite over a real UDP
  socket and event loop, covering the intent/hold wiring most exposed
  to churn in the upstream-owned files.
- `tools/inhibit-agent/test_keying_monitor.cpp` — hang-policy checks
  (SSB hang 0; break-in hang sizing) with no serial and no UDP.
- `tools/send_inhibit_hold.py` sends hold/release datagrams for bench
  testing without a KEY dongle.
- Field-tested with the W2SZ VHF contest group (WIMS KEY agent driving
  holds), including hold/release timing on real radios through
  RX→Tune→RX cycles across release candidates through rc4.
- CI-built on Linux (x86_64/aarch64), Windows, and macOS in the parent
  fork (https://github.com/wa1hco/wsjtx-inhibit).

The branch is based on the released v3.0.2 (`ccdfaf3`), per the
Programmer's Overview. Happy to split into a review-friendly series,
rename the protocol/UI, or adjust to fit the project's direction.

## Since first posting

### Gate seams from the Improved review (commit `2f6d07c`)

A later review of the same feature on the WSJT-X Improved port
produced three small gate seams. Hold policy and wire format are
unchanged.

- `accept()` takes `enable_tx_inhibit_` from `gather_rig_data()`
  (RTS/DTR only). The raw Settings checkbox could stay true under
  CAT/VOX while no gate was running.
- `close_rig()` now emits `tx_inhibit_changed(false)` so the status
  badge cannot stick after the transceiver is torn down.
- A failed `rig_set_ptt` while the gate is driving the pin is
  `pttApplyFailed` → `Transceiver::failure`, not a logged bind error.

The same commit restores Help → About to "About WSJT-X" (fork
branding that had leaked into the first posting).

### KEY agent now on this PR

The first posting left the KEY agent in the working fork. That was
wrong: without an agent the gate only works if the operator already
has WIMS (or writes their own sender). `inhibit-agent` and
`inhibit-agent-gui` are now on this branch so TX Inhibit is usable
on a dual-radio seat that is not a WIMS station.

### Port-0 bind / announce guard (W2SZ field find)

At W2SZ, WIMS dropped InhibitStatus (type 17) when the inhibit port
was 0, so the KEY-agent target list stayed empty. Qt 5 can return true
from `QUdpSocket::bind(0)` while `localPort()` is still 0. This update:

- recovers the OS port with `getsockname` (Windows links `ws2_32`)
- treats a still-zero port as bind failure (no `portBound(0)`)
- never sends a live type 17 with port 0 (port 0 is disable/clear only)
- ignores a latched `portBound(0)` in Configuration

Code and protocol comments say “controllers,” not WIMS. WIMS remains
the field justification above.

### Arming guards

Enable TX Inhibit only when PTT is RTS/DTR and the PTT serial device
is set. `inhibit-agent-gui` shows NEED GATE until the operator Applies
a non-zero UDP inhibit endpoint from type 17 / the tooltip.

Still only in the `wa1hco/wsjtx-inhibit` fork, not this PR: packaging
/ CI / install docs, and the keyboard bench tool `inhibit-test`.

---